### PR TITLE
compatible with `brainstate>=0.1.0`

### DIFF
--- a/braintools/_others/__init__.py
+++ b/braintools/_others/__init__.py
@@ -14,18 +14,9 @@
 # ==============================================================================
 
 
-__version__ = "0.0.4"
+from .spike_encoder import *
+from .spike_encoder import __all__ as encoder_all
 
-from . import file
-from . import input
-from . import metric
-from . import optim
-from . import tree
-from . import visualize
-from ._others import *
-from ._others import __all__ as _other_all
+__all__ = encoder_all
 
-
-__all__ = ['input', 'file', 'metric', 'visualize', 'optim', 'tree'] + _other_all
-
-del _other_all
+del encoder_all

--- a/braintools/_others/spike_encoder.py
+++ b/braintools/_others/spike_encoder.py
@@ -1,0 +1,141 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+from typing import Optional
+
+import brainstate as bst
+import brainunit as u
+import jax
+import numpy as np
+
+__all__ = [
+  'LatencyEncoder',
+]
+
+
+class LatencyEncoder:
+  r"""Encode the rate input as the spike train using the latency encoding.
+
+  Use input features to determine time-to-first spike.
+
+  Expected inputs should be between 0 and 1. If not, the latency encoder will encode ``x``
+  (normalized into ``[0, 1]`` according to
+  :math:`x_{\text{normalize}} = \frac{x-\text{min_val}}{\text{max_val} - \text{min_val}}`)
+  to spikes whose firing time is :math:`0 \le t_f \le \text{num_period}-1`.
+  A larger ``x`` will cause the earlier firing time.
+
+
+  Example::
+
+    >>> import jax
+    >>> a = jax.numpy.array([0.02, 0.5, 1])
+    >>> encoder = LatencyEncoder(method='linear', normalize=True)
+    >>> encoder(a, n_time=5)
+    Array([[0., 0., 1.],
+           [0., 0., 0.],
+           [0., 1., 0.],
+           [0., 0., 0.],
+           [1., 0., 0.]])
+
+
+  Args:
+    min_val: float. The minimal value in the given data `x`, used to the data normalization.
+    max_val: float. The maximum value in the given data `x`, used to the data normalization.
+    method: str. How to convert intensity to firing time. Currently, we support `linear` or `log`.
+      - If ``method='linear'``, the firing rate is calculated as
+        :math:`t_f(x) = (\text{num_period} - 1)(1 - x)`.
+      - If ``method='log'``, the firing rate is calculated as
+        :math:`t_f(x) = (\text{num_period} - 1) - ln(\alpha * x + 1)`,
+        where :math:`\alpha` satisfies :math:`t_f(1) = \text{num_period} - 1`.
+    threshold: float. Input features below the threhold will fire at the
+      final time step unless ``clip=True`` in which case they will not
+      fire at all, defaults to ``0.01``.
+    clip: bool. Option to remove spikes from features that fall
+        below the threshold, defaults to ``False``.
+    tau: float. RC Time constant for LIF model used to calculate
+      firing time, defaults to ``1``.
+    normalize: bool. Option to normalize the latency code such that
+      the final spike(s) occur within num_steps, defaults to ``False``.
+    epsilon: float. A tiny positive value to avoid rounding errors when
+      using torch.arange, defaults to ``1e-7``.
+  """
+
+  def __init__(
+      self,
+      min_val: float = None,
+      max_val: float = None,
+      method: str = 'log',
+      threshold: float = 0.01,
+      clip: bool = False,
+      tau: float = 1. * u.ms,
+      normalize: bool = False,
+      first_spk_time: float = 0. * u.ms,
+      epsilon: float = 1e-7,
+  ):
+    super().__init__()
+
+    if method not in ['linear', 'log']:
+      raise ValueError('The conversion method can only be "linear" and "log".')
+    self.method = method
+    self.min_val = min_val
+    self.max_val = max_val
+    if threshold < 0 or threshold > 1:
+      raise ValueError(f"``threshold`` [{threshold}] must be between [0, 1]")
+    self.threshold = threshold
+    self.clip = clip
+    self.tau = tau
+    self.normalize = normalize
+    self.first_spk_time = first_spk_time
+    self.first_spk_step = int(first_spk_time / bst.environ.get_dt())
+    self.epsilon = epsilon
+
+  def __call__(self, data, n_time: Optional[bst.typing.ArrayLike] = None):
+    """Generate latency spikes according to the given input data.
+
+    Ensuring x in [0., 1.].
+
+    Args:
+      data: The rate-based input.
+      n_time: float. The total time to generate data. If None, use ``tau`` instead.
+
+    Returns:
+      out: array. The output spiking trains.
+    """
+    with jax.ensure_compile_time_eval():
+      if n_time is None:
+        n_time = self.tau
+      tau = n_time if self.normalize else self.tau
+      x = data
+      if self.min_val is not None and self.max_val is not None:
+        x = (x - self.min_val) / (self.max_val - self.min_val)
+
+      # Calculate the spike time
+      dt = bst.environ.get_dt()
+      if self.method == 'linear':
+        spike_time = (tau - self.first_spk_time - dt) * (1 - x) + self.first_spk_time
+
+      elif self.method == 'log':
+        x = u.math.maximum(x, self.threshold + self.epsilon)  # saturates all values below threshold.
+        spike_time = (tau - self.first_spk_time - dt) * u.math.log(x / (x - self.threshold)) + self.first_spk_time
+
+      else:
+        raise ValueError(f'Unsupported method: {self.method}. Only support "log" and "linear".')
+
+      # Clip the spike time
+      if self.clip:
+        spike_time = u.math.where(data < self.threshold, np.inf, spike_time)
+      spike_steps = u.math.round(spike_time / dt).astype(int)
+      return bst.functional.one_hot(spike_steps, num_classes=int(n_time / dt), axis=0, dtype=x.dtype)

--- a/braintools/file/msg_checkpoint.py
+++ b/braintools/file/msg_checkpoint.py
@@ -836,8 +836,6 @@ def msgpack_save(
   if async_manager:
     async_manager.wait_previous_save()
 
-  if os.path.splitext(filename)[-1] != '.bp':
-    filename = filename + '.bp'
   if os.path.dirname(filename):
     os.makedirs(os.path.dirname(filename), exist_ok=True)
   if not overwrite and os.path.exists(filename):

--- a/braintools/input/currents.py
+++ b/braintools/input/currents.py
@@ -306,9 +306,9 @@ def ou_process(mean, sigma, tau, duration, dt=None, n=1, t_start=0., t_end=None,
     x = x + dt * ((mean - x) / tau) + sigma * dt_sqrt * rng.rand(n)
     return x, x
 
-  _, noises = bst.transform.scan(_f,
-                                 u.math.full(n, mean, dtype=bst.environ.dftype()),
-                                 u.math.arange(i_end - i_start))
+  _, noises = bst.compile.scan(_f,
+                               u.math.full(n, mean, dtype=bst.environ.dftype()),
+                               u.math.arange(i_end - i_start))
   currents = u.math.zeros((int(u.maybe_decimal(duration / dt)), n),
                           dtype=bst.environ.dftype(),
                           unit=u.get_unit(noises))

--- a/braintools/input/currents_test.py
+++ b/braintools/input/currents_test.py
@@ -33,6 +33,9 @@ except (ImportError, ModuleNotFoundError):
 block = False
 
 
+bst.environ.set(dt=0.1)
+
+
 def show(current, duration, title=''):
   if plt is not None:
     ts = np.arange(0, duration, bst.environ.get_dt())

--- a/braintools/metric/_correlation.py
+++ b/braintools/metric/_correlation.py
@@ -100,7 +100,7 @@ def cross_correlation(spikes: bst.typing.ArrayLike,
                       lambda _: jnp.sum(states[i] * states[j]) / sqrt_ij,
                       None)
 
-    res = bst.transform.for_loop(_f, *indices)
+    res = bst.compile.for_loop(_f, *indices)
 
   elif method == 'vmap':
     @vmap
@@ -178,7 +178,7 @@ def voltage_fluctuation(potentials, method='loop'):
   avg_var = jnp.mean(avg * avg) - jnp.mean(avg) ** 2
 
   if method == 'loop':
-    _var = bst.transform.for_loop(_f_signal, jnp.moveaxis(potentials, 0, 1))
+    _var = bst.compile.for_loop(_f_signal, jnp.moveaxis(potentials, 0, 1))
   elif method == 'vmap':
     _var = vmap(_f_signal, in_axes=1)(potentials)
   else:

--- a/braintools/metric/_correlation_test.py
+++ b/braintools/metric/_correlation_test.py
@@ -25,6 +25,10 @@ import jax.numpy as jnp
 import brainstate as bst
 
 
+bst.environ.set(dt=0.1)
+
+
+
 class TestCrossCorrelation(unittest.TestCase):
   def test_c(self):
     spikes = jnp.asarray([[1, 0, 1, 0, 1, 0, 1, 0, 0], [1, 1, 1, 1, 1, 1, 1, 0, 0]]).T

--- a/braintools/metric/_firings_test.py
+++ b/braintools/metric/_firings_test.py
@@ -22,6 +22,8 @@ import brainstate as bst
 import braintools as bt
 
 
+bst.environ.set(dt=0.1)
+
 class TestFiringRate(unittest.TestCase):
   def test_fr1(self):
     spikes = jnp.ones((1000, 10))

--- a/braintools/metric/_lfp.py
+++ b/braintools/metric/_lfp.py
@@ -15,9 +15,9 @@
 
 # -*- coding: utf-8 -*-
 
+import brainstate as bst
 import jax
 from jax import numpy as jnp
-import brainstate as bst
 
 __all__ = [
   'unitary_LFP',
@@ -108,7 +108,7 @@ def unitary_LFP(
   # Distributing cells in a 2D grid
   rng = bst.random.RandomState(seed)
   num_neuron = spikes.shape[1]
-  pos_xs, pos_ys = rng.rand(2, num_neuron).value * jnp.array([[xmax], [ymax]])
+  pos_xs, pos_ys = rng.rand(2, num_neuron) * jnp.array([[xmax], [ymax]])
   pos_xs, pos_ys = jnp.asarray(pos_xs), jnp.asarray(pos_ys)
 
   # distance/coordinates
@@ -136,4 +136,4 @@ def unitary_LFP(
   tts = times[iis] + delay[ids]
   exc_amp = A[ids]
   tau = (2 * sig_e * sig_e) if spike_type == 'exc' else (2 * sig_i * sig_i)
-  return bst.transform.for_loop(lambda t: jnp.sum(exc_amp * jnp.exp(-(t - tts) ** 2 / tau)), times)
+  return bst.compile.for_loop(lambda t: jnp.sum(exc_amp * jnp.exp(-(t - tts) ** 2 / tau)), times)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     'numpy',
     'brainstate>=0.1.0',
     'brainunit',
+    'typing_extensions',
 ]
 
 dynamic = ['version']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "numpy", 'jax', 'jaxlib', 'brainstate', 'brainunit']
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 
@@ -48,7 +48,7 @@ dependencies = [
     'jax',
     'jaxlib',
     'numpy',
-    'brainstate',
+    'brainstate>=0.1.0',
     'brainunit',
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jaxlib
 brainunit
 brainstate
 matplotlib
+typing_extensions

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
   author_email='chao.brain@qq.com',
   packages=packages,
   python_requires='>=3.9',
-  install_requires=['numpy>=1.15', 'jax', 'brainstate', 'brainunit'],
+  install_requires=['numpy>=1.15', 'jax', 'brainstate>=0.1.0', 'brainunit'],
   url='https://github.com/chaoming0625/braintools',
   project_urls={
     "Bug Tracker": "https://github.com/chaoming0625/braintools/issues",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,13 @@ setup(
   author_email='chao.brain@qq.com',
   packages=packages,
   python_requires='>=3.9',
-  install_requires=['numpy>=1.15', 'jax', 'brainstate>=0.1.0', 'brainunit'],
+  install_requires=[
+    'numpy>=1.15',
+    'jax',
+    'brainstate>=0.1.0',
+    'brainunit',
+    'typing_extensions',
+  ],
   url='https://github.com/chaoming0625/braintools',
   project_urls={
     "Bug Tracker": "https://github.com/chaoming0625/braintools/issues",


### PR DESCRIPTION
This pull request includes several changes to the `braintools` project, focusing on adding new functionality, updating dependencies, and improving code consistency. The most important changes include the addition of a new spike encoder, updates to licensing information, and modifications to dependency requirements.

### New Functionality:
* Added `LatencyEncoder` class in `braintools/_others/spike_encoder.py` to encode rate input as spike trains using latency encoding.

### Licensing Updates:
* Added Apache License headers to `braintools/_others/__init__.py` and `braintools/_others/spike_encoder.py`. [[1]](diffhunk://#diff-20672336451cb8d1bc9016d000e6279590d04eec38de0b78dfd67e2144ead297R1-R22) [[2]](diffhunk://#diff-abe7c2047f0a75ccfe75a9fec2079a953014990e9d38aaf0c8cc7e3767a76993R1-R141)

### Dependency Updates:
* Updated `pyproject.toml` and `setup.py` to specify a minimum version for the `brainstate` package. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L51-R51) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L62-R62)

### Code Improvements:
* Changed `bst.transform.for_loop` to `bst.compile.for_loop` in multiple files for improved performance. [[1]](diffhunk://#diff-dd851aeac4bf40211c72ff9a1ac3572ab89a8b7e2d47b038aeba103f6010a650L103-R103) [[2]](diffhunk://#diff-dd851aeac4bf40211c72ff9a1ac3572ab89a8b7e2d47b038aeba103f6010a650L181-R181) [[3]](diffhunk://#diff-8d473a0a8f6c047aeb330ea1605777c3c79142835d07d2a53a385e287af3d755L139-R139)
* Modified the `msgpack_save` function in `braintools/file/msg_checkpoint.py` to remove unnecessary file extension checks.

### Import and All Updates:
* Updated `__init__.py` files to include new imports and adjust the `__all__` variable for proper module exports. [[1]](diffhunk://#diff-3bdf90492bc1ad12eb9b87081405b89d62219f9fe5914e067f11ad9814448d20R25-R31) [[2]](diffhunk://#diff-20672336451cb8d1bc9016d000e6279590d04eec38de0b78dfd67e2144ead297R1-R22)