### PR TITLE
msgpack checkpointing support `brainstate.State`

### DIFF
--- a/braintools/file/msg_checkpoint_test.py
+++ b/braintools/file/msg_checkpoint_test.py
@@ -33,7 +33,7 @@ if spec is None:
 
 
 class TestMsgCheckpoint(unittest.TestCase):
-    def test_msg_checkpoint(self):
+    def test_checkpoint_quantity(self):
         data = {
             "name": bst.random.rand(3) * u.ms,
         }
@@ -44,4 +44,28 @@ class TestMsgCheckpoint(unittest.TestCase):
             data['name'] += 1 * u.ms
 
             data2 = bts.file.msgpack_load(filename, target=data)
-            self.assertEqual(data, data2)
+            self.assertTrue('name' in data2)
+            self.assertTrue(isinstance(data2['name'], u.Quantity))
+            self.assertTrue(not u.math.allclose(data['name'], data2['name']))
+
+    def test_checkpoint_state(self):
+        data = {
+            "a": bst.State(bst.random.rand(1)),
+            "b": bst.ShortTermState(bst.random.rand(2)),
+            "c": bst.ParamState(bst.random.rand(3)),
+        }
+
+        with TemporaryDirectory() as tmpdirname:
+            filename = tmpdirname + "/test_msg_checkpoint.msg"
+            bts.file.msgpack_save(filename, data)
+
+            data2 = bts.file.msgpack_load(filename, target=data)
+            self.assertTrue('a' in data2)
+            self.assertTrue('b' in data2)
+            self.assertTrue('c' in data2)
+            self.assertTrue(isinstance(data2['a'], bst.State))
+            self.assertTrue(isinstance(data2['b'], bst.ShortTermState))
+            self.assertTrue(isinstance(data2['c'], bst.ParamState))
+            self.assertTrue(u.math.allclose(data['a'].value, data2['a'].value))
+            self.assertTrue(u.math.allclose(data['b'].value, data2['b'].value))
+            self.assertTrue(u.math.allclose(data['c'].value, data2['c'].value))

--- a/braintools/visualize/style.py
+++ b/braintools/visualize/style.py
@@ -34,5 +34,5 @@ try:
   plt.style.core.update_nested_dict(plt.style.library, {'notebook2': style})
   plt.style.core.available[:] = sorted(plt.style.library.keys())
 
-except (ImportError, ModuleNotFoundError):
+except Exception:
   scienceplots = None


### PR DESCRIPTION
This pull request includes several changes to the `braintools` package, focusing on enhancing the serialization functionality and improving test coverage. The most important changes are grouped by their themes: serialization improvements and test coverage enhancements.

### Serialization Improvements:
* Added `register_serialization_state` calls for `list`, `tuple`, `dict`, `_NamedTuple`, and `bst.State` to ensure proper serialization and deserialization of these types. [[1]](diffhunk://#diff-c6191868750e3a272f8cf6ab5a59be544c492335ddb02d7bd2f8a25428933e38R281-R286) [[2]](diffhunk://#diff-c6191868750e3a272f8cf6ab5a59be544c492335ddb02d7bd2f8a25428933e38R306-R308) [[3]](diffhunk://#diff-c6191868750e3a272f8cf6ab5a59be544c492335ddb02d7bd2f8a25428933e38R332-R361)

### Test Coverage Enhancements:
* Renamed the `test_msg_checkpoint` method to `test_checkpoint_quantity` and added assertions to verify the correctness of quantity serialization. [[1]](diffhunk://#diff-6e65258b19bc552e701b93faf94d7b3e3d0d2f66464f311d6e67303ed3b94bf8L36-R36) [[2]](diffhunk://#diff-6e65258b19bc552e701b93faf94d7b3e3d0d2f66464f311d6e67303ed3b94bf8L47-R71)
* Added a new test method `test_checkpoint_state` to verify the serialization and deserialization of `bst.State`, `bst.ShortTermState`, and `bst.ParamState`.

### Error Handling:
* Modified the exception handling in `braintools/visualize/style.py` to catch all exceptions instead of only `ImportError` and `ModuleNotFoundError`.