### PR TITLE
feat(optim): add SOFO and SOFOScan optimizers

### DIFF
--- a/braintools/optim/__init__.py
+++ b/braintools/optim/__init__.py
@@ -400,6 +400,7 @@ from ._optax_optimizer import (
 # SOFO optimizers
 from ._sofo_optimizer import (
     SOFO,
+    SOFOScan,
 )
 
 __all__ = [
@@ -464,4 +465,5 @@ __all__ = [
 
     # SOFO optimizers
     'SOFO',
+    'SOFOScan',
 ]

--- a/braintools/optim/__init__.py
+++ b/braintools/optim/__init__.py
@@ -397,6 +397,11 @@ from ._optax_optimizer import (
     Fromage,
 )
 
+# SOFO optimizers
+from ._sofo_optimizer import (
+    SOFO,
+)
+
 __all__ = [
     # Base classes
     'Optimizer',
@@ -456,4 +461,7 @@ __all__ = [
     'SM3',
     'Novograd',
     'Fromage',
+
+    # SOFO optimizers
+    'SOFO',
 ]

--- a/braintools/optim/_sofo_optimizer.py
+++ b/braintools/optim/_sofo_optimizer.py
@@ -1,0 +1,309 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# SOFO ("Second-Order Forward-mode Optimization") optimizers.
+# Modified from https://github.com/hennequin-lab/SOFO
+
+from functools import wraps
+from typing import Callable, Optional, Sequence, Union
+
+import brainstate
+import brainunit as u
+import jax
+import jax.numpy as jnp
+import optax
+from brainstate.transform import GradientTransform
+
+from ._optax_optimizer import OptaxOptimizer
+
+__all__ = [
+    'SOFO',
+]
+
+
+# ---------------------------------------------------------------------------
+# math helpers (moved from brainstate.transform._grad_sofo, RNG via brainstate.random)
+# ---------------------------------------------------------------------------
+
+def _batch_jvp(f, W, M, has_aux=False):
+    _jvp = lambda s: jax.jvp(f, (W,), (s,), has_aux=has_aux)
+    return jax.vmap(_jvp)(M)
+
+
+def _batch_jvp_pair(f, W, M, has_aux=False):
+    M_1, M_2 = M
+    _jvp = lambda M_1, M_2: jax.jvp(f, W, (M_1, M_2), has_aux=has_aux)
+    return jax.vmap(_jvp)(M_1, M_2)
+
+
+def _ggn_ce(tangents, h):
+    """Generalised Gauss-Newton matrix for cross-entropy loss. ``tangents`` size (k, dim)."""
+    Jgh = (tangents @ h)[:, None]
+    return (tangents * h) @ tangents.T - Jgh @ Jgh.T  # (k, k)
+
+
+def _ggn_mse(tangents):
+    """Generalised Gauss-Newton matrix for mean-squared loss. ``tangents`` size (k, dim)."""
+    return tangents @ tangents.T
+
+
+def _tree_random_split(rng_key, target):
+    """Split a key into one key per leaf of ``target`` (key management only)."""
+    treedef = jax.tree.structure(target)
+    keys = jax.random.split(rng_key, treedef.num_leaves)
+    return jax.tree.unflatten(treedef, keys)
+
+
+def _sample_v(tangent_size, params, rng):
+    """Sample a batch of globally-normalized tangent vectors matching ``params``.
+
+    Each leaf becomes shape ``(tangent_size, *leaf.shape)``; the batch is normalized by the
+    global L2 norm tangent-wise. Uses ``brainstate.random`` for number generation.
+    """
+    v = jax.tree.map(
+        lambda x, k: brainstate.random.randn(tangent_size, *x.shape, key=k, dtype=x.dtype),
+        params,
+        _tree_random_split(rng, params),
+    )
+    l2 = jnp.sqrt(sum(jax.tree.leaves(jax.vmap(lambda v: jax.tree.map(lambda x: jnp.sum(jnp.square(x)), v))(v))))
+    v = jax.tree.map(lambda x: jax.vmap(lambda a, b: a / b)(x, l2), v)
+    return v
+
+
+def _warp_grad_fn(fn, argnums, args, kwargs):
+    """Partial-apply ``fn`` fixing all args except the one at ``argnums``.
+
+    Reimplemented locally so braintools does not import brainstate private internals.
+    """
+    args = tuple(args)
+    if isinstance(argnums, int):
+        @wraps(fn)
+        def new_fn(dyn_args):
+            new_args = list(args)
+            new_args[argnums] = dyn_args
+            return fn(*new_args, **kwargs)
+
+        assert argnums < len(args), f"argnum {argnums} is out of range {len(args)}"
+        return new_fn, args[argnums]
+    else:
+        @wraps(fn)
+        def new_fn(dyn_args):
+            assert len(dyn_args) == len(argnums)
+            new_args = list(args)
+            for i, argnum in enumerate(argnums):
+                new_args[argnum] = dyn_args[i]
+            return fn(*new_args, **kwargs)
+
+        argnums = (argnums,) if isinstance(argnums, int) else tuple(argnums)
+        params = []
+        for i in argnums:
+            assert i < len(args), f"argnum {i} is out of range {len(args)}"
+            params.append(args[i])
+        return new_fn, params
+
+
+# ---------------------------------------------------------------------------
+# SOFO direction implementation (the `transform=` callable for GradientTransform)
+# ---------------------------------------------------------------------------
+
+def _sofo_grad_impl(
+    fn: Callable,
+    loss_fn: Callable,
+    argnums: Union[int, Sequence[int]] = 0,
+    has_aux: bool = False,
+    return_loss: bool = False,
+    tangent_size: int = 100,
+    damping: float = 1e-5,
+    loss: str = 'mse',
+    key=None,
+) -> Callable:
+    """Forward pass computing the SOFO search direction. Returns ``(h, aux)`` for GradientTransform."""
+
+    def wrapper(*args, **kwargs):
+        f_partial, params = _warp_grad_fn(fn, argnums, args, kwargs)
+        v = _sample_v(tangent_size, params, brainstate.random.split_key() if key is None else key)
+
+        # tangents_out shape: (tangent_size, batch, out)
+        res = _batch_jvp(f_partial, params, v, has_aux=has_aux)
+        if has_aux:
+            outs, tangents_out, aux = res
+            aux = jax.tree.map(lambda x: x[0], aux)
+        else:
+            outs, tangents_out = res
+        losses, vg = _batch_jvp(loss_fn, outs[0], tangents_out)
+
+        if loss == 'mse':
+            vg_gv = u.math.mean(jax.vmap(_ggn_mse, in_axes=1)(tangents_out), axis=0)
+        elif loss == 'ce':
+            vg_gv = u.math.mean(
+                jax.vmap(_ggn_ce, in_axes=(1, 0))(tangents_out, jax.nn.softmax(outs[0], axis=-1)), axis=0
+            )
+        else:
+            raise ValueError(f'Unknown loss function: {loss}.')
+
+        u_, s_, _ = jnp.linalg.svd(vg_gv)
+        damped_s = s_ + damping * jnp.max(s_)
+        vggv_vg = (u_ / damped_s) @ (u_.T @ vg)
+        h = jax.tree.map(lambda v_: jnp.einsum('i,i...->...', vggv_vg, v_), v)
+        if return_loss:
+            return ((h, losses[0]), aux) if has_aux else (h, losses[0])
+        else:
+            return (h, aux) if has_aux else h
+
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# SOFO optimizer
+# ---------------------------------------------------------------------------
+
+class SOFO(OptaxOptimizer):
+    r"""Second-Order Forward-mode Optimization (SOFO) optimizer.
+
+    SOFO computes its own search direction by sampling random tangent vectors, taking
+    forward-mode JVPs through ``model`` and ``loss_fn``, building a Generalised Gauss-Newton
+    matrix in the random subspace, solving a damped linear system, and projecting back to
+    parameter space. The resulting direction is applied via an SGD-style optax update (so
+    learning-rate scheduling, momentum, weight decay, and gradient clipping all work).
+
+    Parameters
+    ----------
+    model : callable
+        The network, called as ``model(inputs)`` returning predictions. Its trainable
+        parameters are the ``brainstate.ParamState`` objects registered via
+        :meth:`register_trainable_weights`.
+    loss_fn : callable
+        ``loss_fn(predictions, targets) -> scalar``.
+    lr : float or LRScheduler, default 1e-3
+        Learning rate.
+    loss : {'mse', 'ce'}, default 'mse'
+        Selects the Generalised Gauss-Newton form.
+    tangent_size : int, default 100
+        Number of random tangents / subspace dimension.
+    damping : float, default 1e-5
+        Damping on the GGN, scaled by the largest singular value.
+    momentum : float, default 0.0
+        Momentum for the SGD-style update.
+    nesterov : bool, default False
+        Whether to use Nesterov momentum.
+    weight_decay : float, default 0.0
+        Decoupled weight decay.
+    grad_clip_norm : float, optional
+        Clip the SOFO direction by global norm before the update.
+    grad_clip_value : float, optional
+        Clip the SOFO direction by value before the update.
+    key : jax PRNG key, optional
+        Random key for tangent sampling. Defaults to ``brainstate.random.split_key()`` each step.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintools
+        >>> import jax.numpy as jnp
+        >>>
+        >>> class MLP(brainstate.nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.l1 = brainstate.nn.Linear(8, 16)
+        ...         self.l2 = brainstate.nn.Linear(16, 3)
+        ...     def __call__(self, x):
+        ...         import jax
+        ...         return self.l2(jax.nn.relu(self.l1(x)))
+        >>>
+        >>> model = MLP()
+        >>> loss_fn = lambda pred, y: jnp.mean((pred - y) ** 2)
+        >>> opt = braintools.optim.SOFO(model, loss_fn, lr=1e-2, tangent_size=64)
+        >>> opt.register_trainable_weights(model.states(brainstate.ParamState))
+        >>> loss = opt.step(jnp.ones((4, 8)), jnp.zeros((4, 3)))  # doctest: +SKIP
+    """
+    __module__ = 'braintools.optim'
+
+    def __init__(
+        self,
+        model: Callable,
+        loss_fn: Callable,
+        lr: float = 1e-3,
+        loss: str = 'mse',
+        tangent_size: int = 100,
+        damping: float = 1e-5,
+        momentum: float = 0.0,
+        nesterov: bool = False,
+        weight_decay: float = 0.0,
+        grad_clip_norm: Optional[float] = None,
+        grad_clip_value: Optional[float] = None,
+        key=None,
+    ):
+        self.model = model
+        self.loss_fn = loss_fn
+        self.loss = loss
+        self.tangent_size = tangent_size
+        self.damping = damping
+        self.momentum = momentum
+        self.nesterov = nesterov
+        self.key = key
+        self._grad_states = None
+        super().__init__(
+            tx=None, lr=lr, weight_decay=weight_decay,
+            grad_clip_norm=grad_clip_norm, grad_clip_value=grad_clip_value,
+        )
+
+    def default_tx(self):
+        transforms = []
+        if self.grad_clip_norm is not None:
+            transforms.append(optax.clip_by_global_norm(self.grad_clip_norm))
+        if self.grad_clip_value is not None:
+            transforms.append(optax.clip(self.grad_clip_value))
+        if self.momentum > 0:
+            transforms.append(optax.trace(decay=self.momentum, nesterov=self.nesterov))
+        if self.weight_decay > 0:
+            transforms.append(optax.add_decayed_weights(self.weight_decay))
+        transforms.append(optax.scale_by_schedule(self._lr_scheduler))
+        return optax.chain(*transforms)
+
+    def register_trainable_weights(self, param_states):
+        super().register_trainable_weights(param_states)
+        self._grad_states = self.param_states.to_pytree()
+        return self
+
+    def _make_grad_fn(self, targets):
+        step_loss_fn = lambda preds: self.loss_fn(preds, targets)
+        return GradientTransform(
+            target=self.model,
+            transform=_sofo_grad_impl,
+            grad_states=self._grad_states,
+            argnums=None,
+            return_value=True,
+            has_aux=False,
+            transform_params=dict(
+                loss=self.loss, tangent_size=self.tangent_size,
+                damping=self.damping, loss_fn=step_loss_fn, key=self.key,
+            ),
+        )
+
+    def _compute_direction(self, inputs, targets):
+        """Return ``(grads, predictions)`` without applying the update (for tests)."""
+        if self.opt_state is None:
+            raise ValueError("register_trainable_weights must be called before step.")
+        return self._make_grad_fn(targets)(inputs)
+
+    def step(self, inputs, targets):
+        grads, predictions = self._compute_direction(inputs, targets)
+        super().step(grads)
+        return self.loss_fn(predictions, targets)
+
+    def update(self, inputs, targets):
+        return self.step(inputs, targets)

--- a/braintools/optim/_sofo_optimizer.py
+++ b/braintools/optim/_sofo_optimizer.py
@@ -30,6 +30,7 @@ from ._optax_optimizer import OptaxOptimizer
 
 __all__ = [
     'SOFO',
+    'SOFOScan',
 ]
 
 
@@ -40,12 +41,6 @@ __all__ = [
 def _batch_jvp(f, W, M, has_aux=False):
     _jvp = lambda s: jax.jvp(f, (W,), (s,), has_aux=has_aux)
     return jax.vmap(_jvp)(M)
-
-
-def _batch_jvp_pair(f, W, M, has_aux=False):
-    M_1, M_2 = M
-    _jvp = lambda M_1, M_2: jax.jvp(f, W, (M_1, M_2), has_aux=has_aux)
-    return jax.vmap(_jvp)(M_1, M_2)
 
 
 def _ggn_ce(tangents, h):
@@ -307,3 +302,155 @@ class SOFO(OptaxOptimizer):
 
     def update(self, inputs, targets):
         return self.step(inputs, targets)
+
+
+# ---------------------------------------------------------------------------
+# SOFOScan: recurrent SOFO optimizer (stateful one-step Module)
+# ---------------------------------------------------------------------------
+
+def _collapse_time(a):
+    """Collapse the leading (time, batch) axes of ``a`` into a single sample axis."""
+    return a.reshape((a.shape[0] * a.shape[1],) + a.shape[2:])
+
+
+class SOFOScan(OptaxOptimizer):
+    r"""Recurrent Second-Order Forward-mode Optimization (SOFO) optimizer.
+
+    Like :class:`SOFO`, but for a stateful one-step recurrent Module. The model is scanned over
+    the input sequence with the hidden state ("latent") carried explicitly; forward-mode JVPs
+    propagate the tangents through time automatically (``jax.jvp`` through ``lax.scan``), so the
+    Generalised Gauss-Newton matrix is accumulated over every (timestep, batch) sample and solved
+    once. The resulting direction is applied via the same SGD-style optax update as :class:`SOFO`.
+
+    Parameters
+    ----------
+    rnn_cell : callable
+        Stateful Module called as ``rnn_cell(latent, inputs) -> (new_latent, output)``, using
+        ``brainstate.ParamState`` objects internally for its trainable weights.
+    loss_fn : callable
+        ``loss_fn(predictions, targets) -> scalar``, where both arguments have their leading
+        ``(time, batch)`` axes collapsed into a single sample axis.
+    lr : float or LRScheduler, default 1e-3
+        Learning rate.
+    loss : {'mse', 'ce'}, default 'mse'
+        Selects the Generalised Gauss-Newton form.
+    tangent_size : int, default 100
+        Number of random tangents / subspace dimension.
+    damping : float, default 1e-5
+        Damping on the GGN, scaled by the largest singular value.
+    momentum : float, default 0.0
+        Momentum for the SGD-style update.
+    nesterov : bool, default False
+        Whether to use Nesterov momentum.
+    weight_decay : float, default 0.0
+        Decoupled weight decay.
+    grad_clip_norm : float, optional
+        Clip the SOFO direction by global norm before the update.
+    grad_clip_value : float, optional
+        Clip the SOFO direction by value before the update.
+    key : jax PRNG key, optional
+        Random key for tangent sampling. Defaults to ``brainstate.random.split_key()`` each step.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintools
+        >>> import jax.numpy as jnp
+        >>>
+        >>> class Cell(brainstate.nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.wh = brainstate.nn.Linear(4, 4)
+        ...         self.wx = brainstate.nn.Linear(3, 4)
+        ...         self.wo = brainstate.nn.Linear(4, 2)
+        ...     def __call__(self, latent, inp):
+        ...         new_latent = self.wh(latent) + self.wx(inp)
+        ...         return new_latent, self.wo(new_latent)
+        >>>
+        >>> cell = Cell()
+        >>> loss_fn = lambda pred, y: jnp.mean((pred - y) ** 2)
+        >>> opt = braintools.optim.SOFOScan(cell, loss_fn, lr=1e-2, tangent_size=64)
+        >>> opt.register_trainable_weights(cell.states(brainstate.ParamState))
+        >>> xs = jnp.ones((5, 4, 3)); ys = jnp.zeros((5, 4, 2)); z0 = jnp.zeros((4, 4))
+        >>> loss = opt.step(z0, (xs, ys))  # doctest: +SKIP
+    """
+    __module__ = 'braintools.optim'
+
+    def __init__(
+        self,
+        rnn_cell: Callable,
+        loss_fn: Callable,
+        lr: float = 1e-3,
+        loss: str = 'mse',
+        tangent_size: int = 100,
+        damping: float = 1e-5,
+        momentum: float = 0.0,
+        nesterov: bool = False,
+        weight_decay: float = 0.0,
+        grad_clip_norm: Optional[float] = None,
+        grad_clip_value: Optional[float] = None,
+        key=None,
+    ):
+        self.rnn_cell = rnn_cell
+        self.loss_fn = loss_fn
+        self.loss = loss
+        self.tangent_size = tangent_size
+        self.damping = damping
+        self.momentum = momentum
+        self.nesterov = nesterov
+        self.key = key
+        self._grad_states = None
+        super().__init__(
+            tx=None, lr=lr, weight_decay=weight_decay,
+            grad_clip_norm=grad_clip_norm, grad_clip_value=grad_clip_value,
+        )
+
+    # reuse SOFO's SGD-style chain (same hyperparameters)
+    default_tx = SOFO.default_tx
+
+    def register_trainable_weights(self, param_states):
+        super().register_trainable_weights(param_states)
+        self._grad_states = self.param_states.to_pytree()
+        return self
+
+    def _scan_model(self, inputs_seq, z_init):
+        def body(latent, inp):
+            new_latent, output = self.rnn_cell(latent, inp)
+            return new_latent, output
+
+        _, outs = brainstate.transform.scan(body, z_init, inputs_seq)  # outs: (T, batch, ...)
+        return _collapse_time(outs)  # (T * batch, ...)
+
+    def _make_grad_fn(self, labels_seq):
+        flat_targets = _collapse_time(labels_seq)
+        step_loss_fn = lambda preds: self.loss_fn(preds, flat_targets)
+        return GradientTransform(
+            target=self._scan_model,
+            transform=_sofo_grad_impl,
+            grad_states=self._grad_states,
+            argnums=None,
+            return_value=True,
+            has_aux=False,
+            transform_params=dict(
+                loss=self.loss, tangent_size=self.tangent_size,
+                damping=self.damping, loss_fn=step_loss_fn, key=self.key,
+            ),
+        )
+
+    def _compute_direction(self, z_init, batch):
+        """Return ``(grads, predictions_flat)`` without applying the update (for tests)."""
+        if self.opt_state is None:
+            raise ValueError("register_trainable_weights must be called before step.")
+        inputs_seq, labels_seq = batch
+        return self._make_grad_fn(labels_seq)(inputs_seq, z_init)
+
+    def step(self, z_init, batch):
+        inputs_seq, labels_seq = batch
+        grads, predictions = self._compute_direction(z_init, batch)
+        super().step(grads)
+        return self.loss_fn(predictions, _collapse_time(labels_seq))
+
+    def update(self, z_init, batch):
+        return self.step(z_init, batch)

--- a/braintools/optim/_sofo_optimizer_test.py
+++ b/braintools/optim/_sofo_optimizer_test.py
@@ -129,3 +129,104 @@ def test_sofo_deterministic_with_fixed_key():
     g3, _ = opt2._compute_direction(x, y)
     l3 = jax.tree.leaves(g3)
     assert any(not jnp.allclose(a, b) for a, b in zip(l1, l3))
+
+
+# ---------------------------------------------------------------------------
+# SOFOScan
+# ---------------------------------------------------------------------------
+
+class LinearRNN(brainstate.nn.Module):
+    """h_t = W_h h_{t-1} + W_x x_t ; output = W_o h_t. Latent passed explicitly.
+
+    Uses default (affine) Linear layers -- the mse GGN is identity regardless of the bias, so
+    the direction test is unaffected. Avoids relying on a bias-disable kwarg whose name may
+    differ across brainstate versions.
+    """
+
+    def __init__(self, n_in, n_hidden, n_out):
+        super().__init__()
+        self.wh = brainstate.nn.Linear(n_hidden, n_hidden)
+        self.wx = brainstate.nn.Linear(n_in, n_hidden)
+        self.wo = brainstate.nn.Linear(n_hidden, n_out)
+
+    def __call__(self, latent, inputs):
+        new_latent = self.wh(latent) + self.wx(inputs)
+        output = self.wo(new_latent)
+        return new_latent, output
+
+
+def _seq_batch(T=5, batch=4, n_in=3, n_out=2, seed=0):
+    rng = brainstate.random.RandomState(seed)
+    xs = rng.randn(T, batch, n_in)
+    ys = rng.randn(T, batch, n_out)
+    return xs, ys
+
+
+def test_sofoscan_reduces_loss():
+    brainstate.random.seed(0)
+    n_in, n_hidden, n_out, batch = 3, 6, 2, 4
+    cell = LinearRNN(n_in, n_hidden, n_out)
+    loss_fn = lambda out, label: jnp.mean((out - label) ** 2)
+    opt = braintools.optim.SOFOScan(cell, loss_fn, lr=1e-2, loss='mse',
+                                    tangent_size=64, damping=1e-5, key=jax.random.PRNGKey(0))
+    opt.register_trainable_weights(cell.states(brainstate.ParamState))
+    xs, ys = _seq_batch(T=5, batch=batch, n_in=n_in, n_out=n_out)
+    z0 = jnp.zeros((batch, n_hidden))
+
+    @brainstate.transform.jit
+    def step(z, b):
+        return opt.step(z, b)
+
+    first = float(step(z0, (xs, ys)))
+    last = first
+    for _ in range(30):
+        last = float(step(z0, (xs, ys)))
+    assert last < first
+
+
+def test_sofoscan_direction_matches_gradient_under_high_damping():
+    """In the high-damping limit SOFO reduces to (subspace-projected) gradient descent, so its
+    direction must align with the true gradient. This validates the scan + forward-mode-JVP math
+    (at low damping the natural-gradient direction differs from the plain gradient by the GGN
+    preconditioner, so it is not a good oracle)."""
+    brainstate.random.seed(3)
+    n_in, n_hidden, n_out, batch = 3, 5, 2, 4
+    cell = LinearRNN(n_in, n_hidden, n_out)
+    loss_fn = lambda out, label: jnp.mean((out - label) ** 2)
+    opt = braintools.optim.SOFOScan(cell, loss_fn, lr=1e-2, loss='mse',
+                                    tangent_size=400, damping=10.0, key=jax.random.PRNGKey(0))
+    params = cell.states(brainstate.ParamState)
+    opt.register_trainable_weights(params)
+    xs, ys = _seq_batch(T=4, batch=batch, n_in=n_in, n_out=n_out, seed=5)
+    z0 = jnp.zeros((batch, n_hidden))
+
+    h, _ = opt._compute_direction(z0, (xs, ys))
+
+    # true gradient of the total (collapsed) scan loss via reverse-mode
+    def total_loss():
+        latent = z0
+        outs = []
+        for t in range(xs.shape[0]):
+            latent, out = cell(latent, xs[t])
+            outs.append(out)
+        preds = jnp.concatenate(outs, axis=0)
+        return jnp.mean((preds - ys.reshape(-1, ys.shape[-1])) ** 2)
+
+    true_grads = brainstate.transform.grad(total_loss, grad_states=params)()
+
+    lh, lt = jax.tree.leaves(h), jax.tree.leaves(true_grads)
+    dot = sum(jnp.sum(a * b) for a, b in zip(lh, lt))
+    nh = jnp.sqrt(sum(jnp.sum(a ** 2) for a in lh))
+    ng = jnp.sqrt(sum(jnp.sum(b ** 2) for b in lt))
+    cos = float(dot / (nh * ng + 1e-12))
+    assert cos > 0.7
+
+
+def test_sofoscan_step_before_register_raises():
+    cell = LinearRNN(3, 4, 2)
+    loss_fn = lambda out, label: jnp.mean((out - label) ** 2)
+    opt = braintools.optim.SOFOScan(cell, loss_fn)
+    xs = jnp.zeros((2, 4, 3))
+    ys = jnp.zeros((2, 4, 2))
+    with pytest.raises(ValueError):
+        opt.step(jnp.zeros((4, 4)), (xs, ys))

--- a/braintools/optim/_sofo_optimizer_test.py
+++ b/braintools/optim/_sofo_optimizer_test.py
@@ -1,0 +1,131 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+# ==============================================================================
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import brainstate
+import braintools
+
+
+class MLP(brainstate.nn.Module):
+    def __init__(self, n_in, n_hidden, n_out):
+        super().__init__()
+        self.l1 = brainstate.nn.Linear(n_in, n_hidden)
+        self.l2 = brainstate.nn.Linear(n_hidden, n_out)
+
+    def __call__(self, x):
+        return self.l2(jax.nn.relu(self.l1(x)))
+
+
+def _fixed_regression_batch(n=32, n_in=8, n_out=3, seed=0):
+    rng = brainstate.random.RandomState(seed)
+    x = rng.randn(n, n_in)
+    y = rng.randn(n, n_out)
+    return x, y
+
+
+def test_sofo_reduces_mse_loss():
+    brainstate.random.seed(0)
+    model = MLP(8, 16, 3)
+    x, y = _fixed_regression_batch()
+    loss_fn = lambda pred, target: jnp.mean((pred - target) ** 2)
+    opt = braintools.optim.SOFO(model, loss_fn, lr=2e-2, loss='mse',
+                                tangent_size=64, damping=1e-5, key=jax.random.PRNGKey(0))
+    opt.register_trainable_weights(model.states(brainstate.ParamState))
+
+    @brainstate.transform.jit
+    def step(bx, by):
+        return opt.step(bx, by)
+
+    first = float(step(x, y))
+    last = first
+    for _ in range(20):
+        last = float(step(x, y))
+    assert last < first
+
+
+def test_sofo_reduces_ce_loss():
+    brainstate.random.seed(1)
+    model = MLP(8, 16, 4)
+    rng = brainstate.random.RandomState(2)
+    x = rng.randn(40, 8)
+    y = rng.randint(0, 4, (40,))
+    loss_fn = lambda pred, target: braintools.metric.softmax_cross_entropy_with_integer_labels(pred, target).mean()
+    opt = braintools.optim.SOFO(model, loss_fn, lr=2e-2, loss='ce',
+                                tangent_size=64, damping=1e-6, key=jax.random.PRNGKey(0))
+    opt.register_trainable_weights(model.states(brainstate.ParamState))
+
+    @brainstate.transform.jit
+    def step(bx, by):
+        return opt.step(bx, by)
+
+    first = float(step(x, y))
+    last = first
+    for _ in range(30):
+        last = float(step(x, y))
+    assert last < first
+
+
+def test_sofo_direction_structure_and_finite():
+    brainstate.random.seed(0)
+    model = MLP(8, 16, 3)
+    x, y = _fixed_regression_batch()
+    loss_fn = lambda pred, target: jnp.mean((pred - target) ** 2)
+    opt = braintools.optim.SOFO(model, loss_fn, lr=1e-2, tangent_size=32, key=jax.random.PRNGKey(0))
+    params = model.states(brainstate.ParamState)
+    opt.register_trainable_weights(params)
+
+    grads, preds = opt._compute_direction(x, y)
+    assert set(grads.keys()) == set(params.keys())
+    assert preds.shape == y.shape
+    for leaf in jax.tree.leaves(grads):
+        assert jnp.all(jnp.isfinite(leaf))
+
+
+def test_sofo_step_before_register_raises():
+    model = MLP(4, 8, 2)
+    loss_fn = lambda pred, target: jnp.mean((pred - target) ** 2)
+    opt = braintools.optim.SOFO(model, loss_fn)
+    with pytest.raises(ValueError):
+        opt.step(jnp.zeros((2, 4)), jnp.zeros((2, 2)))
+
+
+def test_sofo_unknown_loss_raises():
+    brainstate.random.seed(0)
+    model = MLP(4, 8, 2)
+    x, y = _fixed_regression_batch(n=8, n_in=4, n_out=2)
+    loss_fn = lambda pred, target: jnp.mean((pred - target) ** 2)
+    opt = braintools.optim.SOFO(model, loss_fn, loss='bad', key=jax.random.PRNGKey(0))
+    opt.register_trainable_weights(model.states(brainstate.ParamState))
+    with pytest.raises(ValueError):
+        opt.step(x, y)
+
+
+def test_sofo_deterministic_with_fixed_key():
+    # Determinism holds for a fixed set of parameter States: same instance + same key ->
+    # identical direction (the internal grad dict is keyed by id(State), so cross-instance
+    # ordering is not guaranteed -- this is inherent to the design).
+    brainstate.random.seed(7)
+    model = MLP(6, 10, 2)
+    x, y = _fixed_regression_batch(n=16, n_in=6, n_out=2)
+    loss_fn = lambda pred, target: jnp.mean((pred - target) ** 2)
+
+    opt = braintools.optim.SOFO(model, loss_fn, tangent_size=32, key=jax.random.PRNGKey(123))
+    opt.register_trainable_weights(model.states(brainstate.ParamState))
+
+    g1, _ = opt._compute_direction(x, y)
+    g2, _ = opt._compute_direction(x, y)
+    l1, l2 = jax.tree.leaves(g1), jax.tree.leaves(g2)
+    assert len(l1) == len(l2) and len(l1) > 0
+    for a, b in zip(l1, l2):
+        assert jnp.allclose(a, b)
+
+    # a different key produces a different direction (same parameter States)
+    opt2 = braintools.optim.SOFO(model, loss_fn, tangent_size=32, key=jax.random.PRNGKey(999))
+    opt2.register_trainable_weights(model.states(brainstate.ParamState))
+    g3, _ = opt2._compute_direction(x, y)
+    l3 = jax.tree.leaves(g3)
+    assert any(not jnp.allclose(a, b) for a, b in zip(l1, l3))

--- a/docs/apis/optim.rst
+++ b/docs/apis/optim.rst
@@ -89,6 +89,24 @@ offer improved stability in challenging optimization landscapes.
    Novograd
    Fromage
 
+Forward-Mode Optimizers
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+These optimizers compute their own search direction with forward-mode automatic
+differentiation rather than accepting precomputed gradients. SOFO ("Second-Order
+Forward-mode Optimization") samples random tangent vectors, builds a Generalised
+Gauss-Newton matrix in that subspace, and projects a damped natural-gradient direction
+back to parameter space. ``SOFO`` targets feed-forward models; ``SOFOScan`` targets
+stateful one-step recurrent modules scanned over a sequence.
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+   :template: classtemplate.rst
+
+   SOFO
+   SOFOScan
+
 Learning Rate Schedulers
 ------------------------
 


### PR DESCRIPTION
## Summary

Adds **SOFO** (Second-Order Forward-mode Optimization) to `braintools.optim` as two optimizer classes. SOFO computes its own search direction via forward-mode JVPs through the model + loss, builds a Generalised Gauss-Newton matrix in a random tangent subspace, solves a damped system, and projects back to parameter space — applied via the existing `OptaxOptimizer` SGD-style update (so LR scheduling, momentum, weight decay, and gradient clipping all work).

This is the destination half of moving SOFO out of `brainstate.transform` (where it lived as `sofo_grad`/`sofo_grad_scan`) and into `braintools.optim` as a proper optimizer.

- `SOFO(model, loss_fn, ...)` — feed-forward models; `step(inputs, targets)` computes the direction and updates.
- `SOFOScan(rnn_cell, loss_fn, ...)` — stateful one-step recurrent modules; scans over a sequence with `brainstate.transform.scan`, letting forward-mode JVP thread the latent tangents through `lax.scan`. Rebuilt from scratch (the original `sofo_grad_scan` was non-functional).

## Tests

`braintools/optim/_sofo_optimizer_test.py` — 9 tests: mse/ce loss reduction, direction structure/finiteness, error cases, same-instance determinism, SOFOScan loss reduction, and SOFOScan direction matching the true gradient in the high-damping limit. Full `braintools/optim` suite: 391 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add second-order forward-mode optimization (SOFO) as first-class optimizers for feed-forward and recurrent models in braintools.optim.

New Features:
- Introduce SOFO optimizer for feed-forward models that computes a second-order search direction via forward-mode JVPs and applies it through the existing Optax-based SGD-style update stack.
- Add SOFOScan optimizer for stateful recurrent cells, scanning over input sequences while propagating forward-mode tangents through time and optimizing the collapsed sequence loss.

Documentation:
- Document SOFO and SOFOScan optimizers with usage examples and parameter descriptions in the optimizer API docs.

Tests:
- Add unit test suite for SOFO and SOFOScan covering loss reduction for MSE and cross-entropy, direction structure and finiteness, deterministic behavior with fixed random keys, error handling, and alignment with true gradients in the high-damping limit.