### PR TITLE
fix(cogtask): harden Task dispatch, decouple num_classes, validate labels

### DIFF
--- a/braintools/cogtask/conditional.py
+++ b/braintools/cogtask/conditional.py
@@ -29,6 +29,24 @@ __all__ = [
 ]
 
 
+def _coerce_concrete_key(key: Any) -> Any:
+    """Normalize a Switch selector result to a hashable key.
+
+    ``ctx.rng.choice(...)`` (the natural way to pick a random rule in
+    ``trial_init``) returns a 0-d JAX array. In eager ``sample_trial`` that
+    value is *concrete but not a* :class:`jax.core.Tracer`, and it is
+    unhashable — so ``key in cases`` raises ``TypeError``. Coerce such
+    concrete 0-d arrays to a Python scalar so dict lookup works, while
+    leaving tracers (the ``jit``/``vmap`` path) and already-hashable keys
+    (``int``, ``str``) untouched.
+    """
+    if isinstance(key, jax.core.Tracer):
+        return key
+    if hasattr(key, 'ndim') and getattr(key, 'ndim', None) == 0:
+        return key.item()
+    return key
+
+
 class _CompoundCond(Phase):
     """Marker base — these phases manage their own children via ``execute``."""
     IS_COMPOUND = True
@@ -40,6 +58,16 @@ class If(_CompoundCond):
 
     Evaluates the condition at runtime and executes either the `then` phase
     or the `else_` phase (if provided).
+
+    Note
+    ----
+    Under ``batch_sample`` (jit/vmap) the branch is selected with
+    ``jax.lax.cond``, so both branches are traced. The output buffers
+    (``X``/``Y``/``mask``) are correct, but Python-side ``ctx`` state written
+    inside a branch (and ``phase_history``) reflects whichever branch traced
+    last, not the one actually taken. Do not read branch-written ``ctx[...]``
+    values in ``get_trial_meta`` or downstream phases when batching; gate such
+    state on the same condition at the top level instead.
 
     Examples
     --------
@@ -231,7 +259,7 @@ class Switch(_CompoundCond):
 
     def get_duration(self, ctx: Context) -> int:
         """Duration depends on which case is selected."""
-        key = self.selector(ctx)
+        key = _coerce_concrete_key(self.selector(ctx))
         if key in self.cases:
             return self.cases[key].get_duration(ctx)
         elif self.default:
@@ -251,7 +279,7 @@ class Switch(_CompoundCond):
         # which builds a lax.switch over ordered branches; until that path
         # lands we fall back to the default branch (or zero) so the value is
         # still well-typed.
-        key = self.selector(ctx)
+        key = _coerce_concrete_key(self.selector(ctx))
         try:
             phase = self.cases.get(key)
         except TypeError:
@@ -270,7 +298,7 @@ class Switch(_CompoundCond):
 
     def execute(self, ctx: Context) -> None:
         """Execute the phase corresponding to the selector's key."""
-        key = self.selector(ctx)
+        key = _coerce_concrete_key(self.selector(ctx))
         ctx['switch_key'] = key  # Store for debugging/analysis
         if key in self.cases:
             execute_phase(self.cases[key], ctx)
@@ -280,19 +308,69 @@ class Switch(_CompoundCond):
     def execute_packed(self, ctx: Context) -> None:
         """Packed-mode dispatch.
 
-        Selects a branch using ``self.selector(ctx)`` and runs it via
-        :func:`execute_phase_packed`. The selector must return a hashable
-        Python value (string, int, …) — traced selectors would require a
-        ``lax.switch`` based dispatch, which is not currently implemented.
+        When the selector returns a concrete Python value (eager
+        ``sample_trial``, or a selector that ignores trial state) we dispatch
+        with an ordinary ``key in cases`` lookup, which supports arbitrary
+        hashable keys (e.g. strings).
+
+        When the selector returns a *tracer* (under ``jit``/``vmap``, i.e.
+        ``batch_sample``) we dispatch with :func:`jax.lax.switch` over an
+        ordered list of branches. In this path the case keys must be integers
+        — a traced value cannot be a string. Keys not present in ``cases`` (or
+        any value when there is no matching integer key) route to ``default``,
+        or to a no-op when there is no default.
+
+        Note
+        ----
+        Like :meth:`If.execute_packed`, the tensor buffers are threaded through
+        the dispatch and are correct, but Python-side ``ctx`` state written
+        inside a branch is not reliable under tracing (every branch is traced).
+        Do not rely on branch-written ``ctx[...]`` values in
+        ``get_trial_meta``/downstream phases when using ``batch_sample``.
         """
-        key = self.selector(ctx)
+        key = _coerce_concrete_key(self.selector(ctx))
         ctx['switch_key'] = key
-        if key in self.cases:
-            execute_phase_packed(self.cases[key], ctx)
-        elif self.default is not None:
-            execute_phase_packed(self.default, ctx)
-        # Otherwise: no-op. The parent reserved ``max_steps`` worth of
-        # buffer space; we simply don't advance ``t_cursor``.
+
+        if not isinstance(key, jax.core.Tracer):
+            # Concrete dispatch: supports arbitrary hashable keys.
+            if key in self.cases:
+                execute_phase_packed(self.cases[key], ctx)
+            elif self.default is not None:
+                execute_phase_packed(self.default, ctx)
+            # Otherwise: no-op. The parent reserved ``max_steps`` worth of
+            # buffer space; we simply don't advance ``t_cursor``.
+            return
+
+        # Traced dispatch via lax.switch over ordered branches.
+        keys = list(self.cases.keys())
+        phases = list(self.cases.values())
+        state_snapshot = dict(ctx._state)
+
+        def make_branch(phase: Phase):
+            def run(state):
+                ctx._state = dict(state_snapshot)
+                ctx.inputs, ctx.outputs, ctx.mask, ctx.t_cursor = state
+                execute_phase_packed(phase, ctx)
+                return (ctx.inputs, ctx.outputs, ctx.mask, ctx.t_cursor)
+            return run
+
+        branches = [make_branch(p) for p in phases]
+        # Fallback branch (last position): default phase, or an identity no-op.
+        if self.default is not None:
+            branches.append(make_branch(self.default))
+        else:
+            branches.append(lambda state: state)
+        fallback = len(branches) - 1
+
+        # Map the (possibly non-contiguous) integer key to a branch position.
+        index = jnp.asarray(fallback, dtype=jnp.int32)
+        for i, k in enumerate(keys):
+            if isinstance(k, int):  # non-int keys can never match a traced int
+                index = jnp.where(jnp.asarray(key) == k, jnp.int32(i), index)
+
+        state = (ctx.inputs, ctx.outputs, ctx.mask, ctx.t_cursor)
+        new_state = jax.lax.switch(index, branches, state)
+        ctx.inputs, ctx.outputs, ctx.mask, ctx.t_cursor = new_state
 
     def children(self):
         out = list(self.cases.values())
@@ -395,12 +473,30 @@ class While(_CompoundCond):
         ctx['while_total_iterations'] = iteration
 
     def execute_packed(self, ctx: Context) -> None:
-        """Packed-mode loop. The condition must return a Python ``bool``;
-        tracer-valued conditions are not supported here (would require
-        ``lax.while_loop`` with a state-as-pytree wrapper).
+        """Packed-mode loop (eager-only).
+
+        The loop is unrolled in Python, so the condition must evaluate to a
+        concrete ``bool``. This works for eager ``sample_trial`` but NOT under
+        ``jit``/``vmap`` (``batch_sample``) when the condition depends on a
+        traced value: we detect that case and raise a clear
+        :class:`NotImplementedError` instead of a cryptic
+        ``TracerBoolConversionError``. Full traced support would require a
+        ``jax.lax.while_loop`` with the buffers + trial state threaded as a
+        pytree, which is not yet implemented.
         """
         iteration = 0
-        while self.condition(ctx) and iteration < self.max_iterations:
+        while iteration < self.max_iterations:
+            pred = self.condition(ctx)
+            if isinstance(pred, jax.core.Tracer):
+                raise NotImplementedError(
+                    "While with a data-dependent (traced) condition is not "
+                    "supported under jit/vmap (e.g. batch_sample). Evaluate it "
+                    "eagerly via sample_trial, or replace the While with a "
+                    "bounded Repeat / VariableDuration. (Full lax.while_loop "
+                    "support is not yet implemented.)"
+                )
+            if not pred:
+                break
             ctx['while_iteration'] = iteration
             execute_phase_packed(self.body, ctx)
             iteration += 1

--- a/braintools/cogtask/conditional_test.py
+++ b/braintools/cogtask/conditional_test.py
@@ -17,6 +17,7 @@ expose the right context keys (``switch_key``, ``while_iteration``,
 import brainunit as u
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 import braintools.cogtask as ct
 from braintools.cogtask.conditional import If, Switch, While
@@ -173,6 +174,78 @@ def test_switch_with_unknown_key_and_no_default_yields_zero_duration():
     assert int(jnp.sum(info['mask'])) == 3
 
 
+def test_switch_dispatches_under_vmap_with_traced_int_selector():
+    """Under ``batch_sample`` the selector returns a traced int, so Switch must
+    dispatch via ``lax.switch`` rather than a Python ``key in cases`` lookup.
+    Even-index trials take case 0 (short), odd-index trials take case 1 (long)."""
+    fix = ct.Feature(1, 'fixation')
+    a = ct.Feature(1, 'a')
+    out = ct.Feature(1, 'out')
+    phases = ct.concat([
+        Fixation(5 * u.ms, inputs={'fixation': 1.0}, outputs={'label': 0}),
+        Switch(
+            lambda ctx: jnp.asarray(ctx['trial_index']) % 2,
+            cases={
+                0: Stimulus(10 * u.ms, name='case0', inputs={'a': 1.0}, outputs={'label': 1}),
+                1: Stimulus(40 * u.ms, name='case1', inputs={'a': 1.0}, outputs={'label': 2}),
+            },
+        ),
+    ])
+    task = ct.Task(
+        phases=phases, input_features=fix + a, output_features=fix + out,
+        trial_init=lambda ctx: None, seed=0,
+    )
+    X, Y, mask = task.batch_sample(8, return_mask=True)
+    valid = np.asarray(mask.sum(0))
+    # case0 -> 5 + 10 = 15 valid steps; case1 -> 5 + 40 = 45 valid steps.
+    np.testing.assert_array_equal(valid[0::2], 15)
+    np.testing.assert_array_equal(valid[1::2], 45)
+    # Correct branch labels land in the post-fixation region.
+    Y = np.asarray(Y)
+    assert (Y[6, 0::2] == 1).all()   # even trials -> case0 label
+    assert (Y[6, 1::2] == 2).all()   # odd trials  -> case1 label
+
+
+def test_switch_random_rule_works_eager_and_vmap_with_same_selector():
+    """Regression: a Switch driven by a random rule (``rng.choice`` -> a 0-d
+    JAX array) must dispatch correctly with the *same* selector in BOTH eager
+    ``sample_trial`` and ``batch_sample``. Eager used to crash with
+    ``TypeError: unhashable type: 'ArrayImpl'`` because a concrete-but-array
+    key was fed straight into ``key in cases``."""
+    fix = ct.Feature(1, 'fixation')
+    choice = ct.Feature(2, 'choice')
+
+    def mk(marker):
+        return Stimulus(30 * u.ms, inputs={'fixation': float(marker)}, outputs={'label': 0})
+
+    phases = ct.concat([
+        Fixation(10 * u.ms, inputs={'fixation': 9.0}, outputs={'label': 0}),
+        Switch(lambda ctx: ctx['rule'], cases={0: mk(1), 1: mk(2), 2: mk(3)}),
+    ])
+    task = ct.Task(
+        phases=phases, input_features=FeatureSet(fix), output_features=fix + choice,
+        trial_init=lambda ctx: ctx.update(rule=ctx.rng.choice(3).astype(jnp.int32)),
+        seed=5,
+    )
+
+    # Eager path (array key) — the case marker written into the fixation
+    # channel must equal rule + 1.
+    eager = {}
+    for i in range(12):
+        X, _, info = task.sample_trial(i)
+        rule = int(info['trial_state']['rule'])
+        marker = int(round(float(np.asarray(X)[10:40, 0].mean())))
+        assert marker == rule + 1, f"eager trial {i}: rule={rule} marker={marker}"
+        eager[i] = rule
+
+    # Batched path (traced key) — same selector, must match eager per index.
+    Xb, _, _ = task.batch_sample(12, return_mask=True)
+    Xb = np.asarray(Xb)
+    for i in range(12):
+        marker = int(round(float(Xb[10:40, i, 0].mean())))
+        assert marker == eager[i] + 1, f"vmap trial {i}: expected {eager[i] + 1} got {marker}"
+
+
 # ---------------------------------------------------------------------------
 # While
 # ---------------------------------------------------------------------------
@@ -216,6 +289,34 @@ def test_while_respects_max_iterations_safety_limit():
     )
     _, _, info = task.sample_trial(0)
     assert info['trial_state']['while_total_iterations'] == 3
+
+
+def test_while_raises_clear_error_under_vmap_with_traced_condition():
+    """A While whose condition reads a traced value (e.g. an rng-sampled
+    threshold) cannot be traced. ``batch_sample`` must raise an informative
+    error, while eager ``sample_trial`` keeps working."""
+    fix = ct.Feature(1, 'fixation')
+    out = ct.Feature(1, 'out')
+    body = Stimulus(
+        10 * u.ms, inputs={'fixation': 1.0}, outputs={'label': 1},
+        on_exit=lambda ctx: ctx.update(acc=ctx.get('acc', 0.0) + 0.3),
+    )
+
+    def mk():
+        return ct.Task(
+            phases=While(lambda ctx: ctx.get('acc', 0.0) < ctx['thresh'],
+                         body=body, max_iterations=10),
+            input_features=FeatureSet(fix), output_features=fix + out,
+            trial_init=lambda ctx: ctx.update(thresh=ctx.rng.uniform(0.5, 2.5), acc=0.0),
+            seed=0,
+        )
+
+    # Eager path still works (condition is concrete for a single trial).
+    _, _, info = mk().sample_trial(0)
+    assert info['trial_state']['while_total_iterations'] >= 1
+    # Traced (vmap) path raises a clear, actionable error.
+    with pytest.raises(NotImplementedError, match="data-dependent"):
+        mk().batch_sample(4)
 
 
 def test_while_get_duration_uses_max_iterations_as_upper_bound():

--- a/braintools/cogtask/conftest.py
+++ b/braintools/cogtask/conftest.py
@@ -56,9 +56,13 @@ FIXED_DURATION_TASKS = [
     ct.EvidenceAccumulation,
 ]
 
-# Tasks with phases whose duration depends on a value sampled in
-# ``trial_init``. They are valid via ``sample_trial`` but unsafe to vmap
-# because each trial would allocate a different total timestep count.
+# Tasks with phases whose actual duration depends on a value sampled in
+# ``trial_init`` (they contain a VariableDuration / conditional phase). They
+# run in packed mode: buffers are sized to the static ``max_trial_duration``
+# and a per-timestep mask marks the valid steps, so they ARE vmap-safe via
+# ``batch_sample(return_mask=True)`` — see
+# ``task_variable_length_test.test_migrated_builtin_tasks_packed``. They are
+# kept separate only because their valid length varies per trial.
 VARIABLE_DURATION_TASKS = [
     ct.HierarchicalReasoning,
     ct.IntervalDiscrimination,

--- a/braintools/cogtask/encoder.py
+++ b/braintools/cogtask/encoder.py
@@ -461,6 +461,11 @@ def identity(
 
         value = jnp.asarray(value)
 
+        # A 0-d scalar is broadcast to (feature.num,) so callers can store a
+        # plain scalar (e.g. a sampled magnitude) against a single-dim feature.
+        if value.ndim == 0:
+            return jnp.broadcast_to(value, (feature.num,))
+
         # Validate shape
         if value.shape != (feature.num,):
             raise ValueError(

--- a/braintools/cogtask/encoder_test.py
+++ b/braintools/cogtask/encoder_test.py
@@ -197,6 +197,17 @@ def test_identity_rejects_shape_mismatch():
         enc(_ctx(payload=jnp.zeros(4)), Feature(3, 'x'))
 
 
+def test_identity_broadcasts_scalar_to_feature_num():
+    """A 0-d scalar is broadcast to (feature.num,). This is what makes
+    DelayComparison(value_encoding='identity') work: the trial stores a scalar
+    sample/test value while the stimulus feature has num == 1."""
+    enc = identity('payload')
+    out1 = np.asarray(enc(_ctx(payload=0.7), Feature(1, 'x')))
+    np.testing.assert_allclose(out1, [0.7])
+    out3 = np.asarray(enc(_ctx(payload=0.7), Feature(3, 'x')))
+    np.testing.assert_allclose(out3, [0.7, 0.7, 0.7])
+
+
 # ---------------------------------------------------------------------------
 # cos_sin
 # ---------------------------------------------------------------------------

--- a/braintools/cogtask/phase.py
+++ b/braintools/cogtask/phase.py
@@ -601,6 +601,12 @@ def execute_phase_packed(phase: Phase, ctx: Context) -> None:
     ctx.phase_max_steps = max_dur
     ctx.phase_step_count = actual
     ctx.current_phase = phase.name
+    # Expose the phase's trial-level position before ``on_enter`` so hooks see
+    # the same (phase_start, phase_end) contract as the fixed-mode path in
+    # ``execute_phase``. Leaf encoding temporarily repoints these at a local
+    # block and restores them to the slot afterwards.
+    ctx.phase_start = slot_start
+    ctx.phase_end = slot_start + actual
 
     phase.on_enter(ctx)
 
@@ -765,6 +771,12 @@ class DeclarativePhase(Phase):
         Output specification (see shape conventions above).
     noise : dict, optional
         Mapping of feature name → noise sigma (Quantity with unit ms**0.5).
+        Noise is scaled as ``sigma / sqrt(dt)``. The implementation strips
+        units and uses the bare mantissas of ``sigma`` and ``dt``, so it
+        assumes ``dt`` is expressed in milliseconds (the framework default).
+        If you change ``brainstate.environ`` to a non-ms ``dt`` (e.g.
+        seconds), the noise magnitude will be scaled incorrectly — pass
+        ``sigma`` already matched to that unit, or keep ``dt`` in ms.
     on_enter : callable, optional
         Hook called when phase begins.
     on_exit : callable, optional
@@ -798,7 +810,8 @@ class DeclarativePhase(Phase):
         self._task_input_features: Optional[FeatureSet] = None
         self._task_output_features: Optional[FeatureSet] = None
 
-    def bind_features(self, input_features: FeatureSet, output_features: FeatureSet):
+    def bind_features(self, input_features: FeatureSet, output_features: FeatureSet,
+                      num_classes: Optional[int] = None):
         self._task_input_features = input_features
         self._task_output_features = output_features
 
@@ -827,6 +840,23 @@ class DeclarativePhase(Phase):
                 raise ValueError(
                     f"Unknown output feature '{name}' in phase '{self.name}'. "
                     f"Available output features: {[f.name for f in output_features]}"
+                )
+
+        # Catch a *statically* out-of-range categorical label early (e.g. a
+        # typo like ``outputs={'label': 99}``). The only sound upper bound is
+        # ``num_classes`` — the output-feature dimensionality is unrelated to
+        # the label space (that is exactly what ``Task.num_classes`` exists to
+        # decouple). So this only fires when the task declared ``num_classes``
+        # explicitly. Callable / array label specs are data-dependent and
+        # skipped here.
+        label_spec = self._output_specs.get('label')
+        if (num_classes is not None
+                and isinstance(label_spec, int) and not isinstance(label_spec, bool)):
+            if not (0 <= label_spec < num_classes):
+                raise ValueError(
+                    f"Phase '{self.name}': categorical label {label_spec} is out "
+                    f"of range; expected 0 <= label < num_classes "
+                    f"({num_classes})."
                 )
 
     def on_enter(self, ctx: Context) -> None:

--- a/braintools/cogtask/task.py
+++ b/braintools/cogtask/task.py
@@ -24,6 +24,7 @@ import numpy as np
 
 from typing import Optional, Callable, Tuple, Dict, Any, Literal
 from .context import Context
+from .feature import Feature, FeatureSet
 from .phase import (
     Phase,
     Sequence,
@@ -42,6 +43,24 @@ OutputMode = Literal['categorical', 'vector']
 # Sentinel for "no explicit seed". A Task without a seed will draw fresh
 # randomness from brainstate's default RNG on every call.
 _NO_SEED = object()
+
+
+def _drop_string_leaves(meta):
+    """Recursively drop string/bytes leaves from a meta structure.
+
+    ``batch_sample(return_meta=True)`` stacks per-trial meta with ``vmap2``, which
+    requires every leaf to be a JAX type. Tasks that fall back to the default
+    ``get_trial_meta`` return the whole ``trial_state`` dict, which can include
+    descriptive strings (e.g. ``output_mode``). Such constant strings cannot be
+    batched, so they are dropped from the batched meta; numeric fields are kept.
+    """
+    if isinstance(meta, dict):
+        return {k: _drop_string_leaves(v) for k, v in meta.items()
+                if not isinstance(v, (str, bytes))}
+    if isinstance(meta, (list, tuple)):
+        kept = [_drop_string_leaves(v) for v in meta if not isinstance(v, (str, bytes))]
+        return type(meta)(kept)
+    return meta
 
 
 class Task:
@@ -124,6 +143,7 @@ class Task:
         name: Optional[str] = None,
         output_mode: OutputMode = 'categorical',
         seed: Optional[int] = None,
+        num_classes: Optional[int] = None,
         **kwargs
     ):
         for key, value in kwargs.items():
@@ -135,14 +155,38 @@ class Task:
             trial_init = self._class_trial_init
 
         self.phases = phases
-        self.input_features = input_features
-        self.output_features = output_features
+        # Accept a lone Feature in place of a FeatureSet: phases look features
+        # up by name (``name in features``) and slice them (``features[name]``),
+        # which only FeatureSet supports. Wrap so single-channel tasks work.
+        self.input_features = FeatureSet(input_features) if isinstance(input_features, Feature) else input_features
+        self.output_features = FeatureSet(output_features) if isinstance(output_features, Feature) else output_features
+
+        # When phases are supplied directly (instance-based path), features are
+        # mandatory: the phases bind feature slices by name and fail with a
+        # cryptic ``NoneType`` error otherwise. Surface a clear message instead.
+        if self.input_features is None or self.output_features is None:
+            raise ValueError(
+                "When `phases` is provided, both `input_features` and "
+                "`output_features` must be given (got "
+                f"input_features={self.input_features!r}, "
+                f"output_features={self.output_features!r})."
+            )
+
         self._trial_init_func = trial_init
         self.name = name or self.__class__.__name__
 
         if output_mode not in ('categorical', 'vector'):
             raise ValueError(f"Unknown output_mode: {output_mode}")
         self.output_mode: OutputMode = output_mode
+
+        # Number of categorical classes for the 1-D label target. Independent
+        # of the output-feature dimensionality (see the ``num_classes``
+        # property). Set explicitly via the ``num_classes=`` argument or by a
+        # subclass assigning ``self._num_classes`` before ``super().__init__``;
+        # falls back to ``num_outputs`` when left unset.
+        self._num_classes: Optional[int] = (
+            num_classes if num_classes is not None else getattr(self, '_num_classes', None)
+        )
 
         self.seed = seed
         self._root_key: Optional[jax.Array] = (
@@ -227,6 +271,27 @@ class Task:
     @property
     def num_outputs(self) -> int:
         return self.output_features.num
+
+    @property
+    def num_classes(self) -> Optional[int]:
+        """Number of classes for the categorical 1-D label target.
+
+        In ``output_mode='categorical'`` the target ``Y`` is a 1-D integer
+        label array, and the size of a classifier head is the number of
+        distinct label values — which is **independent of**
+        :attr:`num_outputs` (the summed output-feature dimensionality).
+        ``num_outputs`` only coincidentally equals the class count in the
+        default configurations and drifts apart when e.g. ``cue_dim`` changes,
+        so prefer ``num_classes`` when wiring a categorical model head.
+
+        Returns the explicit value passed as ``num_classes=`` when set,
+        otherwise falls back to :attr:`num_outputs` (preserving historical
+        behaviour). Returns ``None`` in ``output_mode='vector'``, where the
+        target is a continuous vector of width :attr:`num_outputs`.
+        """
+        if self.output_mode != 'categorical':
+            return None
+        return self._num_classes if self._num_classes is not None else self.num_outputs
 
     @property
     def dt(self):
@@ -375,7 +440,12 @@ class Task:
         from .phase import DeclarativePhase
 
         if isinstance(phase, DeclarativePhase):
-            phase.bind_features(self.input_features, self.output_features)
+            # Pass the *explicit* class count (None unless the user declared
+            # it) so labels are validated only against a sound upper bound.
+            phase.bind_features(
+                self.input_features, self.output_features,
+                num_classes=self._num_classes if self.output_mode == 'categorical' else None,
+            )
         for child in phase.children():
             self._bind_features_to_phases(child)
 
@@ -414,8 +484,11 @@ class Task:
         mask_axis = 1 if time_first else 0
         if return_mask:
             if return_meta:
+                def _one_mask_meta(i):
+                    X, Y, mask, meta = self.__getitem_with_mask_and_meta__(i)
+                    return X, Y, mask, _drop_string_leaves(meta)
                 X, Y, mask, meta = brainstate.transform.vmap2(
-                    lambda i: self.__getitem_with_mask_and_meta__(i),
+                    _one_mask_meta,
                     out_axes=(out_axes_xy, out_axes_xy, mask_axis, 0)
                 )(indices)
                 return X, Y, mask, meta
@@ -426,8 +499,11 @@ class Task:
                 )(indices)
                 return X, Y, mask
         if return_meta:
+            def _one_meta(i):
+                X, Y, meta = self.__getitem_with_meta__(i)
+                return X, Y, _drop_string_leaves(meta)
             X, Y, meta = brainstate.transform.vmap2(
-                lambda i: self.__getitem_with_meta__(i),
+                _one_meta,
                 out_axes=(out_axes_xy, out_axes_xy, 0)
             )(indices)
             return X, Y, meta
@@ -481,6 +557,7 @@ def create_task(
     name: Optional[str] = None,
     seed: Optional[int] = None,
     output_mode: OutputMode = 'categorical',
+    num_classes: Optional[int] = None,
 ) -> Task:  # noqa: D401
     """
     Convenience factory for creating tasks.
@@ -501,6 +578,10 @@ def create_task(
         Random seed.
     output_mode: OutputMode, optional
         Output mode.
+    num_classes : int, optional
+        Number of categorical classes for the 1-D label target. Used to size a
+        classifier head in ``output_mode='categorical'``; falls back to
+        ``num_outputs`` when unset. Ignored in ``output_mode='vector'``.
 
     Returns
     -------
@@ -520,4 +601,5 @@ def create_task(
     ...     num_trial=1000
     ... )
     """
-    return Task(phases, input_features, output_features, trial_init, name, output_mode=output_mode, seed=seed)
+    return Task(phases, input_features, output_features, trial_init, name,
+                output_mode=output_mode, seed=seed, num_classes=num_classes)

--- a/braintools/cogtask/task_test.py
+++ b/braintools/cogtask/task_test.py
@@ -130,14 +130,23 @@ def test_batch_sample_start_index_changes_trials():
 
 
 def test_batch_sample_with_meta_returns_three_values():
-    # DelayMatchSample overrides get_trial_meta to return (sample_idx, test_idx)
-    # — only such tasks are vmap-safe with return_meta=True, since the default
-    # implementation returns the whole trial_state dict (containing strings).
+    # DelayMatchSample overrides get_trial_meta to return (sample_idx, test_idx).
     task = ct.DelayMatchSample(seed=0)
     X, Y, meta = task.batch_sample(2, return_meta=True)
     assert X.shape[1] == 2
     assert Y.shape[1] == 2
     assert meta is not None
+
+
+def test_batch_sample_with_default_meta_drops_string_leaves():
+    # Tasks that fall back to the default get_trial_meta return the whole
+    # trial_state dict, which includes a string (output_mode). batch_sample
+    # must drop such non-JAX leaves so the numeric meta can be vmap-stacked.
+    task = ct.PerceptualDecisionMaking(seed=0)
+    X, Y, meta = task.batch_sample(4, return_meta=True)
+    assert isinstance(meta, dict)
+    assert 'output_mode' not in meta  # string leaf dropped
+    assert np.asarray(meta['ground_truth']).shape[0] == 4
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +197,26 @@ def test_unknown_output_mode_rejected():
         )
 
 
+def test_single_feature_accepted_without_featureset_wrapper():
+    """A lone Feature (not wrapped in FeatureSet) is accepted as input/output
+    features and normalized internally, so a single-channel task is usable."""
+    fix = ct.Feature(1, 'fixation')
+    task = ct.Task(
+        phases=ct.concat([
+            ct.Fixation(10 * u.ms, inputs={'fixation': 1.0}, outputs={'label': 0}),
+            ct.Response(10 * u.ms, inputs={'fixation': 0.0}, outputs={'label': 1}),
+        ]),
+        input_features=fix,
+        output_features=fix,
+        seed=0,
+    )
+    assert isinstance(task.input_features, FeatureSet)
+    assert isinstance(task.output_features, FeatureSet)
+    X, Y = task[0]
+    assert X.shape == (20, 1)
+    assert Y.shape == (20,)
+
+
 def test_create_task_factory_returns_task_instance():
     fix = ct.Feature(1, 'fix')
     out = ct.Feature(1, 'out')
@@ -197,6 +226,88 @@ def test_create_task_factory_returns_task_instance():
     assert isinstance(task, ct.Task)
     X, Y = task[0]
     assert X.shape[0] == 5
+
+
+# ---------------------------------------------------------------------------
+# num_classes (categorical class count, decoupled from num_outputs)
+# ---------------------------------------------------------------------------
+
+def test_num_classes_defaults_to_num_outputs_categorical():
+    """Backward-compatible default: categorical num_classes == num_outputs."""
+    task = ct.PerceptualDecisionMaking(seed=0)
+    assert task.output_mode == 'categorical'
+    assert task.num_classes == task.num_outputs
+
+
+def test_num_classes_is_none_in_vector_mode():
+    task = ct.DelayDirectionReproduction(seed=0)
+    assert task.output_mode == 'vector'
+    assert task.num_classes is None
+
+
+def test_num_classes_explicit_decouples_from_num_outputs():
+    """An explicit num_classes is independent of the output-feature width,
+    which otherwise grows with e.g. cue_dim while the label space does not."""
+    fix = ct.Feature(1, 'fix')
+    p = ct.concat([
+        ct.Fixation(5 * u.ms, inputs={'fix': 1.0}, outputs={'label': 0}),
+        ct.Response(5 * u.ms, outputs={'label': 1}),
+    ])
+    task = ct.Task(
+        phases=p, input_features=fix, output_features=fix + ct.Feature(4, 'r'),
+        num_classes=3, seed=0,
+    )
+    assert task.num_outputs == 5   # 1 + 4 output-feature dims
+    assert task.num_classes == 3   # but only 3 label classes
+
+    from braintools.cogtask.task import create_task
+    t2 = create_task(p, fix, fix + ct.Feature(4, 'r'), num_classes=2, seed=0)
+    assert t2.num_classes == 2
+
+
+def test_phases_without_features_raises_clear_error():
+    p = ct.Fixation(5 * u.ms, inputs={'fix': 1.0}, outputs={'label': 0})
+    with pytest.raises(ValueError, match="input_features.*output_features"):
+        ct.Task(phases=p, seed=0)
+
+
+def test_out_of_range_literal_label_rejected_when_num_classes_declared():
+    """A literal int label outside [0, num_classes) is caught at bind time when
+    the task declares num_classes (the only sound bound; output dim is not)."""
+    fix = ct.Feature(1, 'fix')
+    p = ct.concat([
+        ct.Fixation(3 * u.ms, inputs={'fix': 1.0}, outputs={'label': 0}),
+        ct.Response(3 * u.ms, outputs={'label': 99}),   # 99 >= num_classes (3)
+    ])
+    with pytest.raises(ValueError, match="out of range"):
+        ct.Task(phases=p, input_features=fix, output_features=fix + ct.Feature(2, 'r'),
+                num_classes=3, seed=0)
+
+
+def test_in_range_literal_label_accepted_with_num_classes():
+    fix = ct.Feature(1, 'fix')
+    p = ct.concat([
+        ct.Fixation(3 * u.ms, inputs={'fix': 1.0}, outputs={'label': 0}),
+        ct.Response(3 * u.ms, outputs={'label': 2}),    # within [0, 3)
+    ])
+    task = ct.Task(phases=p, input_features=fix, output_features=fix + ct.Feature(2, 'r'),
+                   num_classes=3, seed=0)
+    _, Y = task[0]
+    assert int(np.asarray(Y).max()) == 2
+
+
+def test_label_not_validated_without_num_classes():
+    """Without an explicit num_classes there is no sound upper bound (output
+    dim != class count), so literal labels are left unchecked — preserving
+    tasks that encode N classes in fewer output dims."""
+    fix = ct.Feature(1, 'fix')
+    p = ct.concat([
+        ct.Fixation(3 * u.ms, inputs={'fix': 1.0}, outputs={'label': 0}),
+        ct.Response(3 * u.ms, outputs={'label': 1}),    # 1 classes into a 1-dim output
+    ])
+    task = ct.Task(phases=p, input_features=fix, output_features=fix, seed=0)  # num_outputs == 1
+    _, Y = task[0]
+    assert int(np.asarray(Y).max()) == 1
 
 
 def test_class_based_task_without_define_features_raises():

--- a/braintools/cogtask/task_variable_length_test.py
+++ b/braintools/cogtask/task_variable_length_test.py
@@ -246,6 +246,38 @@ def test_if_packed_branches():
     assert bool(jnp.all(M))
 
 
+def test_on_enter_sees_slot_position_in_packed_mode():
+    """In packed (variable-length) mode, a leaf's ``on_enter`` hook must see
+    ``phase_start``/``phase_end`` pointing at its trial slot — the same
+    contract as fixed-mode ``execute_phase`` — not stale values from the
+    previous phase."""
+    fix = Feature(1, 'fixation')
+    seen = {}
+
+    def record(ctx):
+        seen['start'] = int(ctx.phase_start)
+        seen['end'] = int(ctx.phase_end)
+
+    phases = concat([
+        Fixation(50 * u.ms, inputs={'fixation': 1.0}),
+        VariableDuration(
+            min_duration=20 * u.ms, max_duration=200 * u.ms, ctx_key='delay',
+            inputs={'fixation': 1.0}, on_enter=record,
+        ),
+    ])
+
+    def init(ctx):
+        ctx['delay'] = ctx.rng.uniform(20.0, 200.0)
+
+    task = Task(phases=phases, input_features=fix, output_features=Feature(1, 'o'),
+                trial_init=init, seed=0)
+    _, _, info = task.sample_trial(0)
+    # The variable phase starts right after the 50-step fixation.
+    assert seen['start'] == 50
+    # phase_end reflects the phase's own actual (clipped) length, not 0/stale.
+    assert seen['end'] > seen['start']
+
+
 def test_variable_duration_samplers_have_bounds():
     te = ct.TruncExp(500 * u.ms, 200 * u.ms, 1000 * u.ms)
     assert te.is_variable is True

--- a/braintools/cogtask/tasks/working_memory.py
+++ b/braintools/cogtask/tasks/working_memory.py
@@ -699,7 +699,7 @@ class DelayMatchCategory(Task):
     num_categories : int
         Number of categories (default: 2).
     num_exemplars : int
-        Number of exemplars per category (default: 6).
+        Number of exemplars per category (default: 4).
     match_prob : float
         Probability that sample and comparison stimuli belong to the
         same category (default: 0.5).


### PR DESCRIPTION
- Switch: dual-mode packed dispatch — concrete `key in cases` lookup in eager
  mode plus a `lax.switch` over ordered branches under jit/vmap; coerce 0-d
  concrete array keys (e.g. `ctx.rng.choice(...)` selectors) so eager
  `sample_trial` no longer raises "unhashable type: 'ArrayImpl'".
- While: raise a clear NotImplementedError for data-dependent (traced)
  conditions under jit/vmap instead of a cryptic TracerBoolConversionError.
- Task: add `num_classes` (decoupled from `num_outputs`) for sizing
  categorical heads; accept a lone `Feature` in place of a `FeatureSet`;
  require features when `phases` is supplied; drop string leaves from batched
  meta so `vmap2`/`return_meta` works.
- phase: validate statically out-of-range categorical labels against a
  declared `num_classes`; expose `phase_start`/`phase_end` before `on_enter`
  in packed mode so hooks see the same contract as fixed mode.
- encoder, tasks/working_memory: minor fixes.
- Add regression tests covering all of the above.
