### PR TITLE
feat(typing): ship py.typed and annotate public API

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,0 +1,44 @@
+name: Type Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_call:
+
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  mypy:
+    name: mypy (public API surface)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[type-check]"
+      - name: Run mypy on the typed public surface
+        # The full package is still being annotated incrementally; this gate
+        # enforces type-correctness of the maintained public API. The
+        # [tool.mypy] config in pyproject.toml applies (follow_imports=skip,
+        # ignore_missing_imports).
+        run: |
+          mypy \
+            braintools/__init__.py \
+            braintools/_misc.py \
+            braintools/_spike_operation.py \
+            braintools/_spike_encoder.py \
+            braintools/tree.py

--- a/braintools/_misc.py
+++ b/braintools/_misc.py
@@ -21,19 +21,19 @@ import brainunit as u
 import jax
 
 
-def set_module_as(module: str):
-    def wrapper(fun: callable):
+def set_module_as(module: str) -> Callable[[Callable], Callable]:
+    def wrapper(fun: Callable) -> Callable:
         fun.__module__ = module
         return fun
 
     return wrapper
 
 
-def tree_map(f: Callable[..., Any], tree: Any, *rest: Any):
+def tree_map(f: Callable[..., Any], tree: Any, *rest: Any) -> Any:
     return jax.tree.map(f, tree, *rest, is_leaf=u.math.is_quantity)
 
 
-def randn_like(y):
+def randn_like(y: brainstate.typing.ArrayLike) -> jax.Array:
     return brainstate.random.randn(*u.math.shape(y))
 
 

--- a/braintools/_spike_encoder.py
+++ b/braintools/_spike_encoder.py
@@ -87,14 +87,14 @@ class LatencyEncoder:
 
     def __init__(
         self,
-        min_val: float = None,
-        max_val: float = None,
+        min_val: Optional[float] = None,
+        max_val: Optional[float] = None,
         method: str = 'log',
         threshold: float = 0.01,
         clip: bool = False,
-        tau: float = 1. * u.ms,
+        tau: brainstate.typing.ArrayLike = 1. * u.ms,
         normalize: bool = False,
-        first_spk_time: float = 0. * u.ms,
+        first_spk_time: brainstate.typing.ArrayLike = 0. * u.ms,
         epsilon: float = 1e-7,
     ):
         super().__init__()
@@ -114,7 +114,11 @@ class LatencyEncoder:
         self.first_spk_step = int(u.get_mantissa(first_spk_time) / u.get_mantissa(brainstate.environ.get_dt()))
         self.epsilon = epsilon
 
-    def __call__(self, data, n_time: Optional[brainstate.typing.ArrayLike] = None):
+    def __call__(
+        self,
+        data: brainstate.typing.ArrayLike,
+        n_time: Optional[brainstate.typing.ArrayLike] = None,
+    ) -> jax.Array:
         """Generate latency spikes according to the given input data.
 
         Ensuring x in [0., 1.].
@@ -190,10 +194,10 @@ class RateEncoder:
         gain: float = 100.0,
         method: str = 'linear',
         min_rate: float = 0.0,
-        max_rate: float = None,
+        max_rate: Optional[float] = None,
         normalize: bool = False,
-        min_val: float = None,
-        max_val: float = None,
+        min_val: Optional[float] = None,
+        max_val: Optional[float] = None,
     ):
         if method not in ['linear', 'exponential', 'sqrt']:
             raise ValueError('Method must be "linear", "exponential", or "sqrt"')
@@ -206,7 +210,7 @@ class RateEncoder:
         self.min_val = min_val
         self.max_val = max_val
 
-    def __call__(self, data, n_time: int):
+    def __call__(self, data: brainstate.typing.ArrayLike, n_time: int) -> jax.Array:
         """Generate rate-encoded spikes.
         
         Args:
@@ -272,7 +276,7 @@ class PoissonEncoder:
         self.normalize = normalize
         self.max_rate = max_rate
 
-    def __call__(self, data, n_time: int):
+    def __call__(self, data: brainstate.typing.ArrayLike, n_time: int) -> jax.Array:
         """Generate Poisson spike trains.
         
         Args:
@@ -325,7 +329,7 @@ class PopulationEncoder:
         n_neurons: int,
         min_val: float = 0.0,
         max_val: float = 1.0,
-        sigma: float = None,
+        sigma: Optional[float] = None,
         max_rate: float = 100.0,
     ):
         self.n_neurons = n_neurons
@@ -337,7 +341,7 @@ class PopulationEncoder:
         # Create neuron preferred values (centers of receptive fields)
         self.centers = u.math.linspace(min_val, max_val, n_neurons)
 
-    def __call__(self, data, n_time: int):
+    def __call__(self, data: brainstate.typing.ArrayLike, n_time: int) -> jax.Array:
         """Generate population-encoded spikes.
         
         Args:
@@ -405,15 +409,15 @@ class BernoulliEncoder:
         self,
         scale: float = 1.0,
         normalize: bool = True,
-        min_val: float = None,
-        max_val: float = None,
+        min_val: Optional[float] = None,
+        max_val: Optional[float] = None,
     ):
         self.scale = scale
         self.normalize = normalize
         self.min_val = min_val
         self.max_val = max_val
 
-    def __call__(self, data, n_time: int):
+    def __call__(self, data: brainstate.typing.ArrayLike, n_time: int) -> jax.Array:
         """Generate Bernoulli-encoded spikes.
         
         Args:
@@ -469,7 +473,7 @@ class DeltaEncoder:
         self.absolute = absolute
         self.normalize = normalize
 
-    def __call__(self, data):
+    def __call__(self, data: brainstate.typing.ArrayLike) -> jax.Array:
         """Generate delta-encoded spikes.
         
         Args:
@@ -528,8 +532,8 @@ class StepCurrentEncoder:
         current_scale: float = 10.0,  # nA
         offset: float = 0.0,
         normalize: bool = True,
-        min_val: float = None,
-        max_val: float = None,
+        min_val: Optional[float] = None,
+        max_val: Optional[float] = None,
     ):
         self.current_scale = current_scale
         self.offset = offset
@@ -537,7 +541,7 @@ class StepCurrentEncoder:
         self.min_val = min_val
         self.max_val = max_val
 
-    def __call__(self, data, n_time: int):
+    def __call__(self, data: brainstate.typing.ArrayLike, n_time: int) -> jax.Array:
         """Generate step current signals.
         
         Args:
@@ -591,7 +595,7 @@ class SpikeCountEncoder:
         self.distribution = distribution
         self.normalize = normalize
 
-    def __call__(self, data, n_time: int):
+    def __call__(self, data: brainstate.typing.ArrayLike, n_time: int) -> jax.Array:
         """Generate spike count-encoded trains.
         
         Args:
@@ -665,7 +669,7 @@ class TemporalEncoder:
         # Pre-define temporal patterns
         self.patterns = self._create_patterns()
 
-    def _create_patterns(self):
+    def _create_patterns(self) -> dict:
         """Create distinct temporal patterns for each input value."""
         patterns = {}
         for i in range(self.n_patterns):
@@ -677,7 +681,7 @@ class TemporalEncoder:
             patterns[i] = pattern_times
         return patterns
 
-    def __call__(self, data):
+    def __call__(self, data: brainstate.typing.ArrayLike) -> jax.Array:
         """Generate temporally-encoded spikes.
         
         Args:
@@ -741,7 +745,7 @@ class RankOrderEncoder:
         self.normalize = normalize
         self.invert = invert
 
-    def __call__(self, data, n_time: int):
+    def __call__(self, data: brainstate.typing.ArrayLike, n_time: int) -> jax.Array:
         """Generate rank-order encoded spikes.
         
         Args:

--- a/braintools/_spike_operation.py
+++ b/braintools/_spike_operation.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 
 
+from brainstate.typing import ArrayLike
+
 from braintools._misc import set_module_as
 
 __all__ = [
@@ -28,7 +30,7 @@ __all__ = [
 
 
 @set_module_as('braintools')
-def spike_bitwise_or(x, y):
+def spike_bitwise_or(x: ArrayLike, y: ArrayLike) -> ArrayLike:
     """
     Perform a bitwise OR operation on spike tensors.
 
@@ -52,7 +54,7 @@ def spike_bitwise_or(x, y):
 
 
 @set_module_as('braintools')
-def spike_bitwise_and(x, y):
+def spike_bitwise_and(x: ArrayLike, y: ArrayLike) -> ArrayLike:
     """
     Perform a bitwise AND operation on spike tensors.
 
@@ -75,7 +77,7 @@ def spike_bitwise_and(x, y):
 
 
 @set_module_as('braintools')
-def spike_bitwise_iand(x, y):
+def spike_bitwise_iand(x: ArrayLike, y: ArrayLike) -> ArrayLike:
     """
     Perform a bitwise IAND (Inverse AND) operation on spike tensors.
 
@@ -98,7 +100,7 @@ def spike_bitwise_iand(x, y):
 
 
 @set_module_as('braintools')
-def spike_bitwise_not(x):
+def spike_bitwise_not(x: ArrayLike) -> ArrayLike:
     """
     Perform a bitwise NOT operation on spike tensors.
 
@@ -120,7 +122,7 @@ def spike_bitwise_not(x):
 
 
 @set_module_as('braintools')
-def spike_bitwise_xor(x, y):
+def spike_bitwise_xor(x: ArrayLike, y: ArrayLike) -> ArrayLike:
     """
     Perform a bitwise XOR operation on spike tensors.
 
@@ -143,7 +145,7 @@ def spike_bitwise_xor(x, y):
 
 
 @set_module_as('braintools')
-def spike_bitwise_ixor(x, y):
+def spike_bitwise_ixor(x: ArrayLike, y: ArrayLike) -> ArrayLike:
     """
     Perform a bitwise IXOR (Inverse XOR) operation on spike tensors.
 
@@ -166,7 +168,7 @@ def spike_bitwise_ixor(x, y):
 
 
 @set_module_as('braintools')
-def spike_bitwise(x, y, op: str):
+def spike_bitwise(x: ArrayLike, y: ArrayLike, op: str) -> ArrayLike:
     r"""
     Perform bitwise operations on spike tensors.
 

--- a/braintools/_typing_test.py
+++ b/braintools/_typing_test.py
@@ -1,0 +1,173 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests that braintools ships PEP 561 type information and that its public
+API carries usable type annotations consumable by static type checkers."""
+
+import importlib.util
+import inspect
+import sys
+import tomllib
+import typing
+import unittest
+from pathlib import Path
+
+import braintools
+
+# Top-level public files whose annotations are actively maintained and are
+# verified to be clean under mypy (see ``test_mypy_clean_public_surface``).
+TYPED_PUBLIC_MODULES = (
+    '__init__.py',
+    '_misc.py',
+    '_spike_operation.py',
+    '_spike_encoder.py',
+    'tree.py',
+)
+
+SPIKE_OPERATIONS = (
+    'spike_bitwise_or',
+    'spike_bitwise_and',
+    'spike_bitwise_iand',
+    'spike_bitwise_not',
+    'spike_bitwise_xor',
+    'spike_bitwise_ixor',
+    'spike_bitwise',
+)
+
+ENCODERS = (
+    'LatencyEncoder',
+    'RateEncoder',
+    'PoissonEncoder',
+    'PopulationEncoder',
+    'BernoulliEncoder',
+    'DeltaEncoder',
+    'StepCurrentEncoder',
+    'SpikeCountEncoder',
+    'TemporalEncoder',
+    'RankOrderEncoder',
+)
+
+
+def _package_dir() -> Path:
+    return Path(braintools.__file__).resolve().parent
+
+
+def _unannotated_params(func) -> list:
+    """Return the names of parameters lacking annotations (ignoring self/cls
+    and variadic ``*args``/``**kwargs``)."""
+    sig = inspect.signature(func)
+    missing = []
+    for name, param in sig.parameters.items():
+        if name in ('self', 'cls'):
+            continue
+        if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+            continue
+        if param.annotation is inspect.Parameter.empty:
+            missing.append(name)
+    return missing
+
+
+def _has_return_annotation(func) -> bool:
+    return inspect.signature(func).return_annotation is not inspect.Signature.empty
+
+
+class TestPyTypedMarker(unittest.TestCase):
+    """PEP 561: a ``py.typed`` marker must ship inside the package directory."""
+
+    def test_marker_file_present(self):
+        marker = _package_dir() / 'py.typed'
+        self.assertTrue(marker.is_file(), f'py.typed marker missing at {marker}')
+
+    def test_marker_adjacent_to_init(self):
+        # The marker must sit next to __init__.py so type checkers discover it.
+        pkg = _package_dir()
+        self.assertTrue((pkg / '__init__.py').is_file())
+        self.assertTrue((pkg / 'py.typed').is_file())
+
+    def test_pyproject_declares_marker(self):
+        # Only present in a source checkout, not an installed wheel.
+        pyproject = _package_dir().parent / 'pyproject.toml'
+        if not pyproject.is_file():
+            self.skipTest('pyproject.toml not available (installed distribution)')
+        config = tomllib.loads(pyproject.read_text(encoding='utf-8'))
+        package_data = config['tool']['setuptools'].get('package-data', {})
+        self.assertIn('py.typed', package_data.get('braintools', []))
+
+
+class TestPublicApiAnnotations(unittest.TestCase):
+    """The public API surface must carry resolvable type annotations."""
+
+    def test_all_exports_resolvable(self):
+        for name in braintools.__all__:
+            self.assertTrue(
+                hasattr(braintools, name),
+                f'braintools.__all__ advertises {name!r} but it is not importable',
+            )
+
+    def test_spike_operations_fully_annotated(self):
+        for name in SPIKE_OPERATIONS:
+            func = getattr(braintools, name)
+            missing = _unannotated_params(func)
+            self.assertEqual(missing, [], f'{name} has unannotated params: {missing}')
+            self.assertTrue(_has_return_annotation(func), f'{name} lacks a return annotation')
+
+    def test_tree_functions_fully_annotated(self):
+        for name in braintools.tree.__all__:
+            func = getattr(braintools.tree, name)
+            missing = _unannotated_params(func)
+            self.assertEqual(missing, [], f'tree.{name} has unannotated params: {missing}')
+            self.assertTrue(_has_return_annotation(func), f'tree.{name} lacks a return annotation')
+
+    def test_encoder_call_annotated(self):
+        for name in ENCODERS:
+            cls = getattr(braintools, name)
+            call = cls.__call__
+            self.assertTrue(_has_return_annotation(call), f'{name}.__call__ lacks a return annotation')
+            self.assertNotIn('data', _unannotated_params(call), f'{name}.__call__ data param unannotated')
+
+    def test_annotations_resolve_to_real_types(self):
+        # get_type_hints evaluates the (possibly stringized) annotations against
+        # the defining module globals; failure means a typo/undefined name.
+        targets = [getattr(braintools, n) for n in SPIKE_OPERATIONS]
+        targets += [getattr(braintools.tree, n) for n in braintools.tree.__all__]
+        for func in targets:
+            try:
+                hints = typing.get_type_hints(func)
+            except Exception as exc:  # pragma: no cover - surfaced as failure
+                self.fail(f'Could not resolve annotations for {func.__name__}: {exc}')
+            self.assertIn('return', hints, f'{func.__name__} missing resolved return type')
+
+
+class TestStaticTypeChecker(unittest.TestCase):
+    """Run mypy on the maintained public surface when it is installed."""
+
+    def test_mypy_clean_public_surface(self):
+        if importlib.util.find_spec('mypy') is None:
+            self.skipTest('mypy is not installed')
+        from mypy import api
+
+        pkg = _package_dir()
+        files = [str(pkg / name) for name in TYPED_PUBLIC_MODULES]
+        stdout, stderr, exit_status = api.run(
+            files + ['--follow-imports=skip', '--ignore-missing-imports', '--no-error-summary']
+        )
+        self.assertEqual(
+            exit_status, 0,
+            f'mypy reported issues on the public surface:\n{stdout}\n{stderr}',
+        )
+
+
+if __name__ == '__main__':
+    sys.exit(unittest.main())

--- a/braintools/py.typed
+++ b/braintools/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. This package ships inline type information.

--- a/braintools/tree.py
+++ b/braintools/tree.py
@@ -397,7 +397,7 @@ def split(
 
 def idx(
     tree: PyTree[ArrayLike],
-    idx,
+    idx: int | slice | ArrayLike,
     is_leaf: Callable[[Any], bool] | None = u.math.is_quantity
 ) -> PyTree:
     """
@@ -423,7 +423,7 @@ def idx(
 
 def expand(
     tree: PyTree[ArrayLike],
-    axis,
+    axis: int,
     is_leaf: Callable[[Any], bool] | None = u.math.is_quantity
 ) -> PyTree:
     """
@@ -449,7 +449,7 @@ def expand(
 
 def take(
     tree: PyTree[ArrayLike],
-    idx,
+    idx: int | slice | ArrayLike,
     axis: int,
     is_leaf: Callable[[Any], bool] | None = u.math.is_quantity
 ) -> PyTree:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ testing = [
     "absl-py",
     "nevergrad",
 ]
+type-check = [
+    "mypy>=1.8",
+]
 cpu = [
     "jax[cpu]",
 ]
@@ -105,5 +108,21 @@ exclude = [
     "braintools.egg-info*"
 ]
 
+[tool.setuptools.package-data]
+# Ship the PEP 561 marker so type checkers consume braintools' inline types.
+braintools = ["py.typed"]
+
 [tool.setuptools.dynamic]
 version = { attr = "braintools._version.__version__" }
+
+[tool.mypy]
+python_version = "3.11"
+# Many scientific dependencies (jax, brainunit, optax, scipy, ...) ship partial
+# or no type information; don't fail on their missing stubs.
+ignore_missing_imports = true
+# Incremental typing: modules reached via import (third-party and internal code
+# not yet annotated) are treated as untyped rather than reported. This keeps the
+# explicitly type-checked public surface green while annotation coverage grows.
+follow_imports = "skip"
+warn_redundant_casts = true
+warn_unused_ignores = false


### PR DESCRIPTION
Make braintools PEP 561-typed so downstream static type checkers consume
its inline type information, consistent with brainstate/brainunit.

- Add braintools/py.typed marker and ship it via setuptools package-data
- Annotate the top-level public API: spike bitwise ops, spike encoders
  (incl. fixing implicit-Optional defaults), tree utilities, _misc helpers
- Add [tool.mypy] config (incremental: ignore missing imports, skip-follow)
  and a `type-check` optional-dependency group
- Add _typing_test.py verifying the marker ships, the public API carries
  resolvable annotations, and the public surface is mypy-clean
- Add a Type Check GitHub Actions workflow running mypy on that surface
