### PR TITLE
docs(changelog): add #88-#90 to the 0.1.10 release notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,8 +7,9 @@ This release adds two forward-mode second-order optimizers — `SOFO` and
 `SOFOScan` — to `braintools.optim`, and hardens the `braintools.cogtask`
 task engine so that conditional combinators, categorical labels, and
 metadata batching behave correctly under `brainstate.transform.jit` and
-`brainstate.transform.vmap2`. Documentation links and assets are migrated to
-the new `brainx.chaobrain.com` host.
+`brainstate.transform.vmap2`. The package now ships inline type information
+(PEP 561), test coverage is raised to ~92%, and documentation links and
+assets are migrated to the new `brainx.chaobrain.com` host.
 
 ### Highlights
 
@@ -22,6 +23,9 @@ the new `brainx.chaobrain.com` host.
   traced execution, `While` fails loudly on unsupported traced conditions,
   and a new `num_classes` parameter decouples categorical-head sizing from
   `num_outputs`.
+- **PEP 561 typing**: `braintools` ships a `py.typed` marker and inline
+  annotations on its public API, so downstream static type checkers consume
+  its types directly.
 
 ### Added
 
@@ -51,6 +55,19 @@ the new `brainx.chaobrain.com` host.
 - **`Task` feature ergonomics**: `Task` now accepts a lone `Feature` in place
   of a `FeatureSet`, and requires features to be supplied whenever `phases`
   are given.
+- **`Task` time step**: `Task` and `make_task` accept an optional `dt`
+  argument. When set, it is pinned around trial generation via
+  `brainstate.environ.context`, so phase durations and buffer sizes are
+  computed against that `dt` and the reported `dt` stays consistent
+  regardless of the ambient environment. When omitted, the ambient
+  `brainstate.environ.get_dt()` is used (unchanged behaviour).
+
+#### Typing
+
+- **PEP 561 support**: a `braintools/py.typed` marker is shipped via package
+  data, and the top-level public API — spike bitwise ops, spike encoders
+  (with implicit-`Optional` defaults fixed), tree utilities, and `_misc`
+  helpers — now carries resolvable inline annotations.
 
 ### Changed
 
@@ -93,6 +110,13 @@ the new `brainx.chaobrain.com` host.
 - **Docs deployment**: the `push: main` trigger was removed; documentation is
   now deployed only on a GitHub release (`released`) or via a manual
   `workflow_dispatch`.
+- **Type-check workflow**: a new Type Check workflow runs `mypy` over the
+  annotated public surface, backed by a `[tool.mypy]` configuration and a
+  `type-check` optional-dependency group.
+- **Test coverage**: new test suites cover the previously-untested trainer,
+  visualize, file, and surrogate modules, raising overall coverage to ~92%.
+  CI runs `pytest` with `--cov` and uploads results to Codecov, and the
+  README carries a coverage badge.
 
 
 ## Version 0.1.9 (2026-05-21)


### PR DESCRIPTION
The 0.1.10 changelog section was written at #87 and missed three PRs that
landed afterward. This adds them so `changelog.md` matches the (updated)
GitHub release draft.

## Added to the 0.1.10 notes

- **#88** — `cogtask`: optional `dt` on `Task` / `make_task`, pinned around
  trial generation via `brainstate.environ.context` (defaults to
  `environ.get_dt()`).
- **#89** — typing: `py.typed` marker, annotated public API, and the `mypy`
  Type Check CI workflow (PEP 561). New Highlights + Typing subsection.
- **#90** — tests: coverage raised to ~92%, Codecov upload, README badge.

The GitHub `v0.1.10` draft release has already been updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the 0.1.10 changelog to include recent typing, task API, and testing improvements so it matches the v0.1.10 release draft.

Documentation:
- Document PEP 561 typing support, including inline public API annotations, in the 0.1.10 release notes.
- Document the new optional Task dt parameter and its behavior in the 0.1.10 release notes.
- Document expanded tests, increased coverage, Codecov integration, and coverage badge in the 0.1.10 release notes.