### PR TITLE
fix(trainer,visualize): correct six latent API bugs (#92-#97)

### DIFF
--- a/braintools/trainer/_callbacks.py
+++ b/braintools/trainer/_callbacks.py
@@ -461,7 +461,7 @@ class ModelCheckpoint(Callback):
 
     def _save_checkpoint(self, trainer: Any, module: Any, filepath: str):
         """Save a checkpoint."""
-        from braintools.file import msgpack_from_state_dict
+        from braintools.file import msgpack_save
 
         checkpoint = {
             'epoch': module.current_epoch,
@@ -490,7 +490,7 @@ class ModelCheckpoint(Callback):
                 checkpoint['callbacks'][callback.state_key] = cb_state
 
         # Serialize and save
-        msgpack_from_state_dict(checkpoint, filepath)
+        msgpack_save(filepath, checkpoint, verbose=False)
 
         if self.verbose:
             print(f"Saved checkpoint to {filepath}")

--- a/braintools/trainer/_callbacks_test.py
+++ b/braintools/trainer/_callbacks_test.py
@@ -274,21 +274,20 @@ class TestCallbackList:
 
 @pytest.fixture
 def patched_save(monkeypatch):
-    """Replace braintools.file.msgpack_from_state_dict with a real file writer.
+    """Record ModelCheckpoint saves without serializing to disk.
 
-    The production ``_save_checkpoint`` calls ``msgpack_from_state_dict`` with a
-    ``(checkpoint_dict, filepath)`` pair, which the real merge-oriented function
-    does not support.  We patch it with a tiny serializer so the decision logic
-    in ModelCheckpoint can be exercised honestly while still producing files.
+    ``_save_checkpoint`` calls ``braintools.file.msgpack_save(filepath, checkpoint)``.
+    We replace it with a tiny recorder so the decision logic in ModelCheckpoint can
+    be exercised quickly while still producing files.
     """
     saved = []
 
-    def fake(target, path):
+    def fake(path, target, *args, **kwargs):
         saved.append((target, path))
         with open(path, 'wb') as f:
             f.write(b'ckpt')
 
-    monkeypatch.setattr(bf, 'msgpack_from_state_dict', fake)
+    monkeypatch.setattr(bf, 'msgpack_save', fake)
     return saved
 
 
@@ -425,6 +424,20 @@ class TestModelCheckpointSaving:
             cb._save_checkpoint(trainer, model, fp)
             ckpt = patched_save[0][0]
             assert stateful.state_key in ckpt['callbacks']
+
+    def test_save_checkpoint_real_roundtrip(self):
+        # Exercise the real msgpack_save path (no patching) and load it back.
+        with tempfile.TemporaryDirectory() as tmp:
+            cb = ModelCheckpoint(dirpath=tmp)
+            model = FakeModule(current_epoch=3, global_step=42)
+            trainer = FakeTrainer(callbacks=[cb])
+            fp = os.path.join(tmp, 'real.ckpt')
+            cb._save_checkpoint(trainer, model, fp)
+            assert os.path.exists(fp)
+            assert os.path.getsize(fp) > len(b'ckpt')  # real msgpack, not a stub
+            restored = bf.msgpack_load(fp, verbose=False)
+            assert int(restored['epoch']) == 3
+            assert int(restored['global_step']) == 42
 
     def test_on_train_epoch_end_saves_best_min(self, patched_save):
         with tempfile.TemporaryDirectory() as tmp:
@@ -931,13 +944,12 @@ class TestPrintCallback:
 
 class TestIntegration:
     def test_fit_with_callbacks(self, monkeypatch):
-        # Patch the checkpoint serializer so a real fit run can save without
-        # hitting the merge-oriented msgpack_from_state_dict signature.
-        def fake(target, path):
+        # Patch the checkpoint serializer to keep the integration run fast.
+        def fake(path, target, *args, **kwargs):
             with open(path, 'wb') as f:
                 f.write(b'ckpt')
 
-        monkeypatch.setattr(bf, 'msgpack_from_state_dict', fake)
+        monkeypatch.setattr(bf, 'msgpack_save', fake)
 
         with tempfile.TemporaryDirectory() as tmp:
             X = jnp.ones((32, 4))

--- a/braintools/trainer/_module.py
+++ b/braintools/trainer/_module.py
@@ -221,7 +221,9 @@ class LightningModule(brainstate.nn.Module):
                 if hasattr(state, 'value') and hasattr(state.value, 'devices'):
                     devices = state.value.devices()
                     if devices:
-                        return devices[0]
+                        # ``jax.Array.devices()`` returns a set, which is not
+                        # subscriptable; take an arbitrary element instead.
+                        return next(iter(devices))
         return None
 
     # -------------------------------------------------------------------------

--- a/braintools/trainer/_module_test.py
+++ b/braintools/trainer/_module_test.py
@@ -204,6 +204,17 @@ class TestLightningModuleProperties:
         # so the device lookup falls through to None.
         assert model.device is None
 
+    def test_device_property_with_array_param(self):
+        # A ParamState holding a raw JAX array exercises the device lookup;
+        # ``Array.devices()`` returns a set, so the property must not index it.
+        class _ArrModel(braintools.trainer.LightningModule):
+            def __init__(self):
+                super().__init__()
+                self.p = brainstate.ParamState(jnp.ones(3))
+
+        model = _ArrModel()
+        assert model.device is not None
+
 
 class TestLogging:
     """Tests for the logging methods."""

--- a/braintools/visualize/_colormaps.py
+++ b/braintools/visualize/_colormaps.py
@@ -246,7 +246,9 @@ def create_neural_colormap(
         Custom colormap.
     """
     cmap = LinearSegmentedColormap.from_list(name, colors, N=n_bins)
-    plt.colormaps.register(cmap, name=name)
+    # ``force=True`` keeps the call idempotent: re-registering an existing
+    # name overrides it instead of raising.
+    plt.colormaps.register(cmap, name=name, force=True)
     return cmap
 
 

--- a/braintools/visualize/_colormaps_extra_test.py
+++ b/braintools/visualize/_colormaps_extra_test.py
@@ -62,6 +62,12 @@ class TestColormapsExtra(unittest.TestCase):
         self.assertIsInstance(cmap, LinearSegmentedColormap)
         self.assertIn('extra_test_cmap', plt.colormaps)
 
+    def test_create_neural_colormap_idempotent(self):
+        # Registering the same name twice must not raise (force=True).
+        braintools.visualize.create_neural_colormap('extra_dup', ['#000000', '#FFFFFF'])
+        braintools.visualize.create_neural_colormap('extra_dup', ['#FFFFFF', '#000000'])
+        self.assertIn('extra_dup', plt.colormaps)
+
     # ------------------------------------------------------------------
     # brain_colormaps
     # ------------------------------------------------------------------

--- a/braintools/visualize/_plots.py
+++ b/braintools/visualize/_plots.py
@@ -363,7 +363,7 @@ def animate_2D(
     num_step, num_neuron = values.shape
     height, width = net_size
 
-    values = np.asarray(values)
+    values = np.asarray(values).reshape((num_step, height, width))
     val_min = values.min() if val_min is None else val_min
     val_max = values.max() if val_max is None else val_max
 
@@ -387,7 +387,6 @@ def animate_2D(
         title.set_text("Time: {:.2f} ms".format((t + 1) * dt))
         return [mesh, title]
 
-    values = values.reshape((num_step, height, width))
     anim = animation.FuncAnimation(fig=fig,
                                    func=frame,
                                    frames=list(range(1, num_step, frame_step)),
@@ -626,4 +625,4 @@ def remove_axis(ax, *pos):
     for p in pos:
         if p not in ['left', 'right', 'top', 'bottom']:
             raise ValueError
-        ax.spine[p].set_visible(False)
+        ax.spines[p].set_visible(False)

--- a/braintools/visualize/_plots_extra_test.py
+++ b/braintools/visualize/_plots_extra_test.py
@@ -27,6 +27,7 @@ from braintools.visualize._plots import (
     line_plot,
     raster_plot,
     animate_1D,
+    animate_2D,
     remove_axis,
 )
 
@@ -311,13 +312,24 @@ class TestRemoveAxis(unittest.TestCase):
         with self.assertRaises(ValueError):
             remove_axis(ax, 'not-a-side')
 
-    def test_valid_position_executes_body(self):
-        # A valid position passes the validation check and reaches the body.
-        # The source references ``ax.spine`` (an Axes has ``spines``), so the
-        # statement executes and raises AttributeError - covering that line.
+    def test_valid_position_hides_spine(self):
+        # Valid positions hide the corresponding spines.
         fig, ax = plt.subplots()
-        with self.assertRaises(AttributeError):
-            remove_axis(ax, 'left')
+        remove_axis(ax, 'left', 'top')
+        self.assertFalse(ax.spines['left'].get_visible())
+        self.assertFalse(ax.spines['top'].get_visible())
+
+
+class TestAnimate2D(unittest.TestCase):
+
+    def tearDown(self):
+        plt.close('all')
+
+    def test_animate_2d_runs(self):
+        # values: (num_step, num_neuron) reshaped to a (height, width) grid.
+        values = np.random.rand(5, 12)
+        anim = animate_2D(values, net_size=(3, 4), dt=0.1, show=False)
+        self.assertIsNotNone(anim)
 
 
 if __name__ == '__main__':

--- a/braintools/visualize/_statistical.py
+++ b/braintools/visualize/_statistical.py
@@ -100,7 +100,14 @@ def correlation_matrix(
     elif method == 'spearman':
         corr_matrix = stats.spearmanr(data)[0]
     elif method == 'kendall':
-        corr_matrix = stats.kendalltau(data)[0]
+        # ``kendalltau`` only compares two 1-D samples, so build the
+        # feature-by-feature matrix pairwise.
+        n_features = data.shape[1]
+        corr_matrix = np.ones((n_features, n_features))
+        for i in range(n_features):
+            for j in range(i + 1, n_features):
+                tau = stats.kendalltau(data[:, i], data[:, j])[0]
+                corr_matrix[i, j] = corr_matrix[j, i] = tau
     else:
         raise ValueError(f"Unknown correlation method: {method}")
 

--- a/braintools/visualize/_statistical_extra_test.py
+++ b/braintools/visualize/_statistical_extra_test.py
@@ -45,13 +45,11 @@ class TestStatisticalExtra(unittest.TestCase):
         self.assertIsInstance(ax, plt.Axes)
 
     def test_correlation_matrix_kendall(self):
-        # scipy.stats.kendalltau does not accept a single 2D matrix the way
-        # spearmanr does, so the 'kendall' branch raises for matrix input.
-        # We still exercise the dispatch + call line and assert it errors.
-        with self.assertRaises(Exception):
-            braintools.visualize.correlation_matrix(
-                self.data[:, :3], method='kendall', show_values=False
-            )
+        # The 'kendall' branch builds the matrix pairwise over feature columns.
+        ax = braintools.visualize.correlation_matrix(
+            self.data[:, :3], method='kendall', show_values=False
+        )
+        self.assertIsInstance(ax, plt.Axes)
 
     def test_correlation_matrix_mask_diagonal_and_no_colorbar(self):
         fig, ax = plt.subplots()

--- a/changelog.md
+++ b/changelog.md
@@ -101,6 +101,19 @@ assets are migrated to the new `brainx.chaobrain.com` host.
     correctly under `brainstate.transform.vmap2`.
   - Minor fixes to the input encoder and the working-memory task library.
   - Added regression tests covering all of the above.
+- **`braintools.trainer`**:
+  - `LightningModule.device` no longer raises on array-backed parameters;
+    `Array.devices()` returns a set, which is now handled correctly (#92).
+  - `ModelCheckpoint` saves through `braintools.file.msgpack_save` instead of
+    a state-restore helper, so checkpoints are written correctly (#95).
+- **`braintools.visualize`**:
+  - `animate_2D` reshapes the value grid before drawing the first frame,
+    fixing a `pcolor` crash on the initial step (#93).
+  - `correlation_matrix(method='kendall')` builds the matrix pairwise instead
+    of passing a 2-D array to `kendalltau` (#94).
+  - `remove_axis` uses `ax.spines` instead of the non-existent `ax.spine` (#96).
+  - `create_neural_colormap` / `brain_colormaps` register with `force=True`,
+    making them idempotent rather than raising on re-use (#97).
 
 ### Infrastructure
 
@@ -116,7 +129,8 @@ assets are migrated to the new `brainx.chaobrain.com` host.
 - **Test coverage**: new test suites cover the previously-untested trainer,
   visualize, file, and surrogate modules, raising overall coverage to ~92%.
   CI runs `pytest` with `--cov` and uploads results to Codecov, and the
-  README carries a coverage badge.
+  README carries a coverage badge. `tqdm` and `rich` were added to the
+  `testing` extra so the progress-bar tests run in CI.
 
 
 ## Version 0.1.9 (2026-05-21)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ testing = [
     "pytest-cov",
     "absl-py",
     "nevergrad",
+    "tqdm",
+    "rich",
 ]
 type-check = [
     "mypy>=1.8",


### PR DESCRIPTION
## Summary

Fixes six latent API bugs surfaced while raising braintools test coverage above 90% (#90). Each bug is a hard crash (`TypeError`/`AttributeError`/wrong-API) on a documented public call path; all are covered by the regression tests added here.

| Issue | Symptom | Fix |
|-------|---------|-----|
| #92 | `LightningModule.device` → `TypeError: 'set' object is not subscriptable` | `jax.Array.devices()` returns a set; take `next(iter(...))` |
| #93 | `visualize.animate_2D` → pcolor called on a 1-D array | reshape values to the `(height, width)` grid before `FuncAnimation` |
| #94 | `visualize.correlation_matrix(method='kendall')` → `kendalltau` rejects a 2-D matrix | build the correlation matrix pairwise over feature columns |
| #95 | `trainer.ModelCheckpoint` cannot save — uses `msgpack_from_state_dict` (a restorer) as a writer | write with `file.msgpack_save` |
| #96 | `visualize.remove_axis` → `AttributeError: 'Axes' object has no attribute 'spine'` | `ax.spine` → `ax.spines` |
| #97 | `create_neural_colormap`/`brain_colormaps` raise on re-register | register with `force=True` (idempotent) |

## CI

Adds `tqdm` and `rich` to the `testing` extra so the progress-bar callback tests (`TestTQDMProgressBar`) actually run in CI instead of being silently skipped — this is what broke `main` after #90 merged.

## Verification

Full suite green locally (`pytest braintools --cov`), total coverage **91.77%**. Tests previously asserting the buggy behaviour were updated to assert the fixed behaviour.

## Notes

Changelog updated under v0.1.10.

Closes #92, #93, #94, #95, #96, #97

## Summary by Sourcery

Fix trainer checkpointing and device detection and resolve multiple visualize API crashes, adding regression tests and restoring CI progress-bar coverage.

Bug Fixes:
- Ensure LightningModule.device works with array-backed parameters by handling jax.Array.devices() correctly.
- Fix ModelCheckpoint to write checkpoints via the msgpack_save API so saves succeed and can be restored.
- Update animate_2D to reshape inputs to the specified grid before drawing, preventing pcolor from crashing.
- Make correlation_matrix(method='kendall') compute pairwise feature correlations instead of passing a 2-D matrix to kendalltau.
- Correct remove_axis to operate on ax.spines so valid positions hide the intended axes without raising.
- Make create_neural_colormap and brain_colormaps idempotent by forcing re-registration instead of raising on reuse.

CI:
- Add tqdm and rich to the testing extra so progress-bar callback tests run in CI instead of being skipped.

Documentation:
- Update changelog entries to document trainer and visualize bug fixes and CI testing changes.

Tests:
- Add regression tests for LightningModule.device with array parameters and for real ModelCheckpoint save/load roundtrips.
- Extend visualize tests to cover animate_2D execution, remove_axis spine hiding, Kendall correlation matrices, and idempotent colormap registration.