### PR TITLE
fix(visualize): use np.trapezoid for AUC/AP, restoring NumPy >=2.4 (#99)

### DIFF
--- a/braintools/visualize/_statistical.py
+++ b/braintools/visualize/_statistical.py
@@ -23,6 +23,11 @@ import scipy.stats as stats
 from braintools._misc import set_module_as
 from braintools.tree import as_numpy
 
+# ``np.trapz`` was renamed to ``np.trapezoid`` in NumPy 2.0 and removed
+# outright in NumPy 2.4, so resolve whichever name the installed NumPy
+# provides (falling back to ``np.trapz`` for NumPy < 2.0).
+_trapezoid = getattr(np, 'trapezoid', None) or np.trapz
+
 __all__ = [
     'correlation_matrix',
     'distribution_plot',
@@ -922,7 +927,7 @@ def roc_curve(
     fpr = np.array(fpr)
 
     # Calculate AUC
-    auc = np.trapz(tpr, fpr)
+    auc = _trapezoid(tpr, fpr)
 
     # Plot ROC curve
     ax.plot(fpr, tpr, color=color, linewidth=2, label=f'AUC = {auc:.3f}', **kwargs)
@@ -1003,7 +1008,7 @@ def precision_recall_curve(
     recall = np.array(recall)
 
     # Calculate average precision
-    ap = np.trapz(precision, recall)
+    ap = _trapezoid(precision, recall)
 
     # Plot PR curve
     ax.plot(recall, precision, color=color, linewidth=2,

--- a/changelog.md
+++ b/changelog.md
@@ -114,6 +114,9 @@ assets are migrated to the new `brainx.chaobrain.com` host.
   - `remove_axis` uses `ax.spines` instead of the non-existent `ax.spine` (#96).
   - `create_neural_colormap` / `brain_colormaps` register with `force=True`,
     making them idempotent rather than raising on re-use (#97).
+  - `roc_curve` / `precision_recall_curve` resolve `np.trapezoid` when
+    available (falling back to `np.trapz`), fixing an `AttributeError` on
+    NumPy >= 2.4 where `np.trapz` was removed (#99).
 
 ### Infrastructure
 


### PR DESCRIPTION
## Summary

Hotfix: `main` CI went red after #98 because the new `test_precision_recall_curve` coverage test exercised `braintools.visualize.precision_recall_curve`, which (along with `roc_curve`) calls `np.trapz`.

`np.trapz` was renamed to `np.trapezoid` in NumPy 2.0 and **removed** in NumPy 2.4. CI installs `numpy 2.4.6`, so both functions raised:

```
AttributeError: module 'numpy' has no attribute 'trapz'. Did you mean: 'trace'?
```

It was invisible locally because local environments had NumPy < 2.4.

## Fix

Resolve the integration routine once at import time, preferring `np.trapezoid` and falling back to `np.trapz` for the declared `numpy>=1.15` floor:

```python
_trapezoid = getattr(np, 'trapezoid', None) or np.trapz
```

Both call sites (`roc_curve` AUC, `precision_recall_curve` AP) now use `_trapezoid`. Same signature, same semantics.

## Verification

`pytest braintools/visualize/_statistical_extra_test.py braintools/visualize/_statistical_test.py` → **43 passed** locally, where `_trapezoid` resolves to `np.trapezoid` (the same path CI's NumPy 2.4.6 takes).

Closes #99

## Summary by Sourcery

Ensure ROC and precision-recall visualization metrics work with newer NumPy versions by using a compatible trapezoidal integration helper.

Bug Fixes:
- Fix AttributeError in `roc_curve` and `precision_recall_curve` when running with NumPy >= 2.4 by resolving a compatible trapezoidal integration function at import time.

Documentation:
- Document the NumPy compatibility fix for `roc_curve` and `precision_recall_curve` in the changelog.