### PR TITLE
fix(conn): avoid array-truthiness in CompositeConnectivity union

### DIFF
--- a/braintools/conn/_base.py
+++ b/braintools/conn/_base.py
@@ -590,8 +590,8 @@ class CompositeConnectivity(Connectivity):
             'delays': delays,
             'pre_size': result1.pre_size,
             'post_size': result1.post_size,
-            'pre_positions': result1.pre_positions or result2.pre_positions,
-            'post_positions': result1.post_positions or result2.post_positions,
+            'pre_positions': result1.pre_positions if result1.pre_positions is not None else result2.pre_positions,
+            'post_positions': result1.post_positions if result1.post_positions is not None else result2.post_positions,
             'model_type': result1.model_type,
             'metadata': merge_dict(
                 result1.metadata,


### PR DESCRIPTION
## Problem

`CompositeConnectivity._union` built the merged result with:

```python
'pre_positions': result1.pre_positions or result2.pre_positions,
'post_positions': result1.post_positions or result2.post_positions,
```

The `or` forces `bool()` on a multi-element position `Quantity` array, raising `ValueError: The truth value of an array with more than one element is ambiguous`. This broke `braintools/conn/_kernel_test.py::TestSobelKernel::test_sobel_both` on py3.13 across ubuntu/macos/windows in both the regular **CI** and the **Scheduled (nightly) CI**.

## Fix

Use an explicit `is not None` check (the pattern already used elsewhere in this module) instead of array truthiness.

## Verification

- Reproduced the failure locally, confirmed fix resolves it.
- Full test suite: **3171 passed, 0 failed, 10 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent ValueError when merging CompositeConnectivity results by avoiding boolean evaluation of multi-element position arrays in _union.