### PR TITLE
fix(quad): resolve unit-handling & noise-sampling bugs; add audit + tests to 100% coverage

### DIFF
--- a/braintools/quad/__init__.py
+++ b/braintools/quad/__init__.py
@@ -36,12 +36,11 @@ making them ideal for simulation loops with minimal boilerplate.
 .. code-block:: python
 
     import brainstate as bst
-    import brainunit as u
     import jax.numpy as jnp
     from braintools.quad import ode_euler_step, ode_rk4_step
 
-    # Set global time step
-    bst.environ.set(dt=0.01 * u.ms)
+    # Set global time step (dimensionless for this simple scalar ODE)
+    bst.environ.set(dt=0.01)
 
     # Define ODE: dy/dt = -y + sin(t)
     def f(y, t):
@@ -49,14 +48,14 @@ making them ideal for simulation loops with minimal boilerplate.
 
     # Simple Euler integration
     y = 0.0
-    t = 0.0 * u.ms
+    t = 0.0
     for _ in range(100):
         y = ode_euler_step(f, y, t)
         t += bst.environ.get_dt()
 
     # Higher accuracy with RK4
     y = 0.0
-    t = 0.0 * u.ms
+    t = 0.0
     for _ in range(100):
         y = ode_rk4_step(f, y, t)
         t += bst.environ.get_dt()
@@ -66,12 +65,10 @@ making them ideal for simulation loops with minimal boilerplate.
 .. code-block:: python
 
     import brainstate as bst
-    import brainunit as u
-    import jax.numpy as jnp
     from braintools.quad import sde_euler_step, sde_milstein_step
 
-    # Set global time step
-    bst.environ.set(dt=0.1 * u.ms)
+    # Set global time step (dimensionless for this simple scalar SDE)
+    bst.environ.set(dt=0.1)
 
     # Define SDE: dy = -y*dt + 0.5*dW
     def drift(y, t):
@@ -82,14 +79,14 @@ making them ideal for simulation loops with minimal boilerplate.
 
     # Euler-Maruyama integration
     y = 1.0
-    t = 0.0 * u.ms
+    t = 0.0
     for _ in range(1000):
         y = sde_euler_step(drift, diffusion, y, t)
         t += bst.environ.get_dt()
 
     # Higher accuracy with Milstein
     y = 1.0
-    t = 0.0 * u.ms
+    t = 0.0
     for _ in range(1000):
         y = sde_milstein_step(drift, diffusion, y, t)
         t += bst.environ.get_dt()
@@ -102,19 +99,18 @@ making them ideal for simulation loops with minimal boilerplate.
     import brainunit as u
     import jax.numpy as jnp
     from braintools.quad import (
-        ode_euler_step, ode_rk2_step, ode_rk4_step,
-        ode_midpoint_step, ode_heun_step,
-        ode_rk4_38_step, ode_expeuler_step,
-        ode_dopri5_step, ode_rk23_step
+        ode_euler_step, ode_rk2_step, ode_rk3_step, ode_rk4_step,
+        ode_midpoint_step, ode_heun_step, ode_rk4_38_step,
+        ode_expeuler_step, ode_dopri5_step, ode_rk23_step
     )
 
     bst.environ.set(dt=0.01 * u.ms)
 
-    # Define a simple neuron model
-    def neuron_ode(V, t, I_ext=0.0):
+    # A simple leaky-integrator neuron model
+    def neuron_ode(V, t, I_ext=0.0 * u.nA):
         tau = 20.0 * u.ms
         V_rest = -65.0 * u.mV
-        R = 10.0 * u.MOhm
+        R = 10.0 * u.Mohm
         return (V_rest - V + R * I_ext) / tau
 
     V = -65.0 * u.mV
@@ -126,7 +122,10 @@ making them ideal for simulation loops with minimal boilerplate.
     # Second-order methods
     V = ode_rk2_step(neuron_ode, V, t, I_ext=0.5 * u.nA)
     V = ode_midpoint_step(neuron_ode, V, t, I_ext=0.5 * u.nA)
-    V = ode_heun_step(neuron_ode, V, t, I_ext=0.5 * u.nA)
+
+    # Third-order methods
+    V = ode_rk3_step(neuron_ode, V, t, I_ext=0.5 * u.nA)
+    V = ode_heun_step(neuron_ode, V, t, I_ext=0.5 * u.nA)  # Heun's RK3
 
     # Fourth-order methods
     V = ode_rk4_step(neuron_ode, V, t, I_ext=0.5 * u.nA)
@@ -136,18 +135,9 @@ making them ideal for simulation loops with minimal boilerplate.
     V = ode_rk23_step(neuron_ode, V, t, I_ext=0.5 * u.nA)  # Bogacki-Shampine
     V = ode_dopri5_step(neuron_ode, V, t, I_ext=0.5 * u.nA)  # Dormand-Prince
 
-    # Exponential Euler (for stiff linear parts)
-    def linear_coeff(V, t):
-        tau = 20.0 * u.ms
-        return -1.0 / tau
-
-    def nonlinear_part(V, t, I_ext=0.0):
-        tau = 20.0 * u.ms
-        V_rest = -65.0 * u.mV
-        R = 10.0 * u.MOhm
-        return (V_rest + R * I_ext) / tau
-
-    V = ode_expeuler_step(linear_coeff, nonlinear_part, V, t, I_ext=0.5 * u.nA)
+    # Exponential Euler takes a single drift function and linearizes it
+    # internally (well suited to stiff, near-linear dynamics).
+    V = ode_expeuler_step(neuron_ode, V, t, I_ext=0.5 * u.nA)
 
 **SDE Integrators:**
 
@@ -159,20 +149,22 @@ making them ideal for simulation loops with minimal boilerplate.
     from braintools.quad import (
         sde_euler_step, sde_milstein_step,
         sde_expeuler_step, sde_heun_step,
-        sde_srk2_step, sde_tamed_euler_step
+        sde_srk2_step, sde_srk3_step, sde_tamed_euler_step
     )
 
     bst.environ.set(dt=0.01 * u.ms)
 
-    # Stochastic neuron with current noise
-    def drift(V, t, I_mean=0.0):
+    # Stochastic neuron with current noise. The steppers forward extra kwargs to
+    # *both* drift and diffusion, so both accept **kwargs. A diffusion coefficient
+    # has units of [state] / sqrt([time]).
+    def drift(V, t, I_mean=0.0 * u.nA, **kwargs):
         tau = 20.0 * u.ms
         V_rest = -65.0 * u.mV
-        R = 10.0 * u.MOhm
+        R = 10.0 * u.Mohm
         return (V_rest - V + R * I_mean) / tau
 
-    def diffusion(V, t, noise_sigma=0.1):
-        return noise_sigma * u.mV / u.ms
+    def diffusion(V, t, noise_sigma=0.1, **kwargs):
+        return noise_sigma * u.mV / u.ms ** 0.5
 
     V = -65.0 * u.mV
     t = 0.0 * u.ms
@@ -193,18 +185,9 @@ making them ideal for simulation loops with minimal boilerplate.
     # Tamed Euler (for stiff SDEs)
     V = sde_tamed_euler_step(drift, diffusion, V, t, I_mean=0.5 * u.nA)
 
-    # Exponential Euler (linearized drift)
-    def linear_drift(V, t):
-        tau = 20.0 * u.ms
-        return -1.0 / tau
-
-    def nonlinear_drift(V, t, I_mean=0.0):
-        tau = 20.0 * u.ms
-        V_rest = -65.0 * u.mV
-        R = 10.0 * u.MOhm
-        return (V_rest + R * I_mean) / tau
-
-    V = sde_expeuler_step(linear_drift, nonlinear_drift, diffusion, V, t)
+    # Exponential Euler (drift is linearized internally; signature is
+    # sde_expeuler_step(drift, diffusion, y, t, *args))
+    V = sde_expeuler_step(drift, diffusion, V, t, I_mean=0.5 * u.nA)
 
 **IMEX Integrators:**
 
@@ -219,17 +202,20 @@ making them ideal for simulation loops with minimal boilerplate.
 
     bst.environ.set(dt=0.01 * u.ms)
 
-    # Split system: stiff linear + nonstiff nonlinear
-    # Example: V' = -V/tau (stiff) + f(V) (nonstiff)
+    # Split the leaky-integrator neuron V' = (V_rest - V + R*I)/tau into a
+    # nonstiff input/reversal part (explicit) and the stiff decay -V/tau
+    # (implicit). Both parts are rates with units [state]/[time]. The steppers
+    # forward extra kwargs to both parts, so both accept **kwargs.
 
     # Explicit (nonstiff) part
-    def f_explicit(V, t, I_ext=0.0):
+    def f_explicit(V, t, I_ext=0.0 * u.nA, **kwargs):
+        tau = 20.0 * u.ms
         V_rest = -65.0 * u.mV
-        R = 10.0 * u.MOhm
-        return V_rest + R * I_ext
+        R = 10.0 * u.Mohm
+        return (V_rest + R * I_ext) / tau
 
     # Implicit (stiff) part
-    def f_implicit(V, t):
+    def f_implicit(V, t, **kwargs):
         tau = 20.0 * u.ms
         return -V / tau
 
@@ -242,15 +228,16 @@ making them ideal for simulation loops with minimal boilerplate.
     # Second-order ARS(2,2,2) method
     V = imex_ars222_step(f_explicit, f_implicit, V, t, I_ext=0.5 * u.nA)
 
-    # Crank-Nicolson + Adams-Bashforth
-    V = imex_cnab_step(f_explicit, f_implicit, V, t, I_ext=0.5 * u.nA)
+    # Crank-Nicolson + Adams-Bashforth (multistep: also needs the previous
+    # state y_{n-1}; on the first step pass the current state)
+    V_prev = V
+    V = imex_cnab_step(f_explicit, f_implicit, V, V_prev, t, I_ext=0.5 * u.nA)
 
 **DDE Integrators:**
 
 .. code-block:: python
 
     import brainstate as bst
-    import brainunit as u
     import jax.numpy as jnp
     from collections import deque
     from braintools.quad import (
@@ -258,26 +245,22 @@ making them ideal for simulation loops with minimal boilerplate.
         dde_euler_pc_step, dde_heun_pc_step
     )
 
-    bst.environ.set(dt=0.1 * u.ms)
+    bst.environ.set(dt=0.1)
 
-    # Delayed feedback system: dy/dt = -y(t) + tanh(y(t-τ))
-    delay = 5.0 * u.ms
+    # Delayed feedback system: dy/dt = -y(t) + tanh(y(t - delay))
+    delay = 5.0
+    dt = bst.environ.get_dt()
+    n_hist = int(delay / dt) + 1
 
-    # Simple history storage
-    history = deque(maxlen=int(delay / bst.environ.get_dt()) + 1)
-    times = deque(maxlen=int(delay / bst.environ.get_dt()) + 1)
+    # History buffers seeded over the delay interval (constant IC y = 0.1)
+    history = deque([0.1] * n_hist, maxlen=n_hist)
+    times = deque([-delay + i * dt for i in range(n_hist)], maxlen=n_hist)
 
-    # Initialize history
-    y = 0.1
-    for i in range(len(history)):
-        history.append(y)
-        times.append(-delay + i * bst.environ.get_dt())
-
-    # History function (linear interpolation)
+    # History lookup: nearest stored sample, clamped to the buffer.
+    # Replace with proper interpolation for production use.
     def history_fn(t_past):
-        # Find closest stored values and interpolate
-        # (simplified example - use proper interpolation in practice)
-        idx = min(max(0, int((t_past - times[0]) / bst.environ.get_dt())), len(history)-1)
+        idx = int(round((t_past - times[0]) / dt))
+        idx = min(max(idx, 0), len(history) - 1)
         return history[idx]
 
     # DDE right-hand side
@@ -285,30 +268,28 @@ making them ideal for simulation loops with minimal boilerplate.
         return -y + jnp.tanh(y_delayed)
 
     # Integration loop
-    t = 0.0 * u.ms
+    y = 0.1
+    t = 0.0
     for _ in range(100):
         # Euler method for DDEs
         y_new = dde_euler_step(f, y, t, history_fn, delays=delay)
 
-        # Or use higher-order methods
+        # Or use higher-order / predictor-corrector methods:
         # y_new = dde_heun_step(f, y, t, history_fn, delays=delay)
         # y_new = dde_rk4_step(f, y, t, history_fn, delays=delay)
-
-        # Or predictor-corrector methods
         # y_new = dde_euler_pc_step(f, y, t, history_fn, delays=delay)
 
         # Update history
         history.append(y_new)
         times.append(t)
         y = y_new
-        t += bst.environ.get_dt()
+        t += dt
 
     # Multiple delays example
     def f_multi(t, y, y_delay1, y_delay2):
         return -y + 0.5 * jnp.tanh(y_delay1) + 0.3 * jnp.sin(y_delay2)
 
-    delays = [5.0 * u.ms, 10.0 * u.ms]
-    y_new = dde_euler_step(f_multi, y, t, history_fn, delays=delays)
+    y_new = dde_euler_step(f_multi, y, t, history_fn, delays=[5.0, 10.0])
 
 **PyTree State Integration:**
 
@@ -321,38 +302,35 @@ making them ideal for simulation loops with minimal boilerplate.
 
     bst.environ.set(dt=0.01 * u.ms)
 
-    # Complex state as PyTree (dictionary)
+    # State as a PyTree (dictionary) with mixed physical units
     state = {
         'V': -65.0 * u.mV,
-        'w': 0.0,
         'Ca': 0.1 * u.uM,
     }
 
-    # ODE for complex state
-    def neuron_dynamics(state, t, I_ext=0.0):
-        V, w, Ca = state['V'], state['w'], state['Ca']
+    # ODE for the PyTree state (each leaf is a rate [state]/[time])
+    def neuron_dynamics(state, t, I_ext=0.0 * u.nA):
+        V, Ca = state['V'], state['Ca']
         tau_V = 20.0 * u.ms
-        tau_w = 100.0 * u.ms
         tau_Ca = 50.0 * u.ms
+        R = 10.0 * u.Mohm
 
-        dV = (-V + 65 * u.mV + 10 * u.MOhm * I_ext - w) / tau_V
-        dw = (-w + 0.5 * (V + 65 * u.mV)) / tau_w
+        dV = (-65.0 * u.mV - V + R * I_ext) / tau_V
         dCa = (-Ca + 0.1 * u.uM) / tau_Ca
 
-        return {'V': dV, 'w': dw, 'Ca': dCa}
+        return {'V': dV, 'Ca': dCa}
 
     # Integration preserves PyTree structure
     state = ode_rk4_step(neuron_dynamics, state, 0.0 * u.ms, I_ext=1.0 * u.nA)
 
-    # SDE with PyTree state
+    # SDE with PyTree state (diffusion units are [state]/sqrt([time]))
     def drift(state, t):
         return neuron_dynamics(state, t, I_ext=0.5 * u.nA)
 
     def diffusion(state, t):
         return {
-            'V': 0.1 * u.mV / u.ms,
-            'w': 0.0,
-            'Ca': 0.01 * u.uM / u.ms,
+            'V': 0.1 * u.mV / u.ms ** 0.5,
+            'Ca': 0.01 * u.uM / u.ms ** 0.5,
         }
 
     state = sde_euler_step(drift, diffusion, state, 0.0 * u.ms)
@@ -362,25 +340,26 @@ making them ideal for simulation loops with minimal boilerplate.
 .. code-block:: python
 
     import brainstate as bst
-    import brainunit as u
     import jax.numpy as jnp
-    from braintools.quad import ode_rk23_step, ode_rk45_step, ode_dopri5_step
+    from braintools.quad import (
+        ode_rk23_step, ode_rk45_step, ode_dopri5_step, ode_dopri8_step
+    )
 
-    bst.environ.set(dt=0.01 * u.ms)
+    bst.environ.set(dt=0.01)
 
-    # Embedded RK methods return both solutions for error estimation
+    # Pass return_error=True to embedded methods to also get an error estimate.
     def f(y, t):
         return -y + jnp.sin(10 * t)
 
     y = 1.0
-    t = 0.0 * u.ms
+    t = 0.0
 
     # RK23 (Bogacki-Shampine 2(3))
-    y_new = ode_rk23_step(f, y, t)
+    y_new, err = ode_rk23_step(f, y, t, return_error=True)
 
-    # RK45 (Cash-Karp or Dormand-Prince 4(5))
+    # RK45 (Cash-Karp 4(5)) and DOPRI5 (Dormand-Prince 5(4))
     y_new = ode_rk45_step(f, y, t)
-    y_new = ode_dopri5_step(f, y, t)  # Same as ode_rk45_dopri_step
+    y_new = ode_dopri5_step(f, y, t)  # alias: ode_rk45_dopri_step
 
     # DOP853 (Dormand-Prince 8(7)) - high accuracy
     y_new = ode_dopri8_step(f, y, t)
@@ -390,11 +369,10 @@ making them ideal for simulation loops with minimal boilerplate.
 .. code-block:: python
 
     import brainstate as bst
-    import brainunit as u
     import jax.numpy as jnp
     from braintools.quad import ode_ssprk33_step
 
-    bst.environ.set(dt=0.001 * u.ms)
+    bst.environ.set(dt=0.001)
 
     # SSPRK(3,3) - third-order SSP Runge-Kutta
     # Useful for problems with discontinuities or shocks
@@ -403,7 +381,7 @@ making them ideal for simulation loops with minimal boilerplate.
         return -jnp.roll(y, 1) + y
 
     y = jnp.ones(100)
-    t = 0.0 * u.ms
+    t = 0.0
 
     y = ode_ssprk33_step(f, y, t)
 

--- a/braintools/quad/_dde_integrator.py
+++ b/braintools/quad/_dde_integrator.py
@@ -103,7 +103,7 @@ def dde_euler_step(
     
     >>> def f(t, y, y_delayed):
     ...     return -y + y_delayed  # Simple delayed feedback
-    >>> y_next = dde_euler_step(f, y, t, history_fn, delay=1.0)
+    >>> y_next = dde_euler_step(f, y, t, history_fn, delays=1.0)
     
     Multiple delays case:
     

--- a/braintools/quad/_ode_integrator.py
+++ b/braintools/quad/_ode_integrator.py
@@ -264,26 +264,24 @@ def ode_expeuler_step(
     r"""
     One-step Exponential Euler method for ODEs with linearized drift.
 
-    Examples
-    --------
+    The drift ``f`` is linearized around the current state via its diagonal
+    Jacobian ``A = \partial f / \partial y`` and the linear part is integrated
+    exactly over one step:
 
-    >>> def fun(x, t):
-    ...     return -x
-    >>> x = 1.0
-    >>> exp_euler_step(fun, x， 0.)
+    .. math::
 
-    If the variable ( $x$ ) has units of ( $[X]$ ), then the drift term ( $\text{drift_fn}(x)$ ) should
-    have units of ( $[X]/[T]$ ), where ( $[T]$ ) is the unit of time.
+        y_{n+1} = y_n + \Delta t\, \varphi(\Delta t\, A)\, f(y_n, t_n),
+        \qquad \varphi(z) = \frac{e^{z} - 1}{z}.
 
-    If the variable ( x ) has units of ( [X] ), then the diffusion term ( \text{diffusion_fn}(x) )
-    should have units of ( [X]/\sqrt{[T]} ).
+    For a scalar linear ODE ``dy/dt = A y`` the method is exact. If the state
+    ``y`` has unit ``[X]``, the drift ``f(y, t)`` must have unit ``[X]/[T]``.
 
     Parameters
     ----------
     f : callable
         Drift function ``f(y, t, *args)`` used in the exponential update.
-    y : PyTree
-        Current state. Must have a floating dtype.
+    y : ArrayLike
+        Current state. Must have a floating dtype (float16/32/64 or bfloat16).
     t : float or brainunit.Quantity
         Current time.
     *args
@@ -291,18 +289,50 @@ def ode_expeuler_step(
 
     Returns
     -------
-    PyTree
+    ArrayLike
         The updated state ``y_{n+1}``.
+
+    Raises
+    ------
+    ValueError
+        If ``y`` does not have a floating dtype.
+
+    See Also
+    --------
+    ode_euler_step : Explicit (forward) Euler step.
+    sde_expeuler_step : Exponential Euler step for SDEs.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import brainunit as u
+        >>> from braintools.quad import ode_expeuler_step
+        >>> def fun(x, t):
+        ...     return -x
+        >>> with brainstate.environ.context(dt=0.1):
+        ...     x_next = ode_expeuler_step(fun, 1.0, 0.0)
+        >>> float(x_next)  # exp(-0.1)
+        0.904837429523468
+
+        >>> with brainstate.environ.context(dt=0.1 * u.ms):
+        ...     v_next = ode_expeuler_step(lambda v, t: -v / (10.0 * u.ms),
+        ...                                -65.0 * u.mV, 0.0 * u.ms)
     """
     assert callable(f), 'The input function should be callable.'
     if u.math.get_dtype(y) not in [jnp.float32, jnp.float64, jnp.float16, jnp.bfloat16]:
         raise ValueError(
             f'The input data type should be float64, float32, float16, or bfloat16 '
-            f'when using Exponential Euler method. But we got {y.dtype}.'
+            f'when using Exponential Euler method. But we got {u.math.get_dtype(y)}.'
         )
     dt = brainstate.environ.get('dt')
     linear, derivative = brainstate.transform.vector_grad(f, argnums=0, return_value=True)(y, t, *args, **kwargs)
-    linear = u.Quantity(u.get_mantissa(linear), u.get_unit(derivative) / u.get_unit(linear))
+    # ``vector_grad`` returns the diagonal Jacobian ``J = df/dy`` whose physical
+    # unit is ``unit(f)/unit(y)``. Divide by the *state* unit (not the Jacobian's
+    # own unit) so ``dt * linear`` is dimensionless; otherwise ``u.math.exprel``
+    # rejects it for unitful states.
+    linear = u.Quantity(u.get_mantissa(linear), u.get_unit(derivative) / u.get_unit(y))
     phi = u.math.exprel(dt * linear)
     x_next = y + dt * phi * derivative
     return x_next
@@ -686,18 +716,8 @@ def ode_dopri5_step(
     )
     k6 = f(y6, t + dt * 1.0, *args, **kwargs)
 
-    # Compute k7 stage at t+dt
-    y7 = tree_map(
-        lambda x, _k1, _k3, _k4, _k5, _k6: x + dt * ((35.0 / 384.0) * _k1 +
-                                                     (500.0 / 1113.0) * _k3 +
-                                                     (125.0 / 192.0) * _k4 +
-                                                     (-2187.0 / 6784.0) * _k5 +
-                                                     (11.0 / 84.0) * _k6),
-        y, k1, k3, k4, k5, k6
-    )
-    k7 = f(y7, t + dt, *args, **kwargs)
-
-    # 5th-order solution (b5)
+    # 5th-order solution (b5). This is also the 7th stage point ``y7`` (the
+    # DOPRI5 pair is FSAL), so ``k7 = f(y5th, t + dt)`` below reuses it.
     y5th = tree_map(
         lambda x, _k1, _k3, _k4, _k5, _k6: x + dt * ((35.0 / 384.0) * _k1 +
                                                      (500.0 / 1113.0) * _k3 +
@@ -710,7 +730,8 @@ def ode_dopri5_step(
     if not return_error:
         return y5th
 
-    # 4th-order embedded (b4) uses k7
+    # 4th-order embedded (b4) uses k7 = f(y5th, t + dt) (FSAL: y7 == y5th)
+    k7 = f(y5th, t + dt, *args, **kwargs)
     y4th = tree_map(lambda x, _k1, _k3, _k4, _k5, _k6, _k7: x + dt * ((5179.0 / 57600.0) * _k1 +
                                                                       (7571.0 / 16695.0) * _k3 +
                                                                       (393.0 / 640.0) * _k4 +
@@ -1144,7 +1165,7 @@ def ode_dopri8_step(
             coeffs = [c for (_, c) in row]
             ks = [K[j] for (j, _) in row]
             y_s = affine_sum(y, coeffs, ks)
-        else:
+        else:  # pragma: no cover - unreachable: DOP853 stages 1..11 all have non-empty A rows
             y_s = y
         t_s = t + C[s] * dt
         K[s] = f(y_s, t_s, *args, **kwargs)

--- a/braintools/quad/_quad_coverage_test.py
+++ b/braintools/quad/_quad_coverage_test.py
@@ -1,0 +1,368 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Comprehensive edge-case / branch / unit-invariance tests for ``braintools.quad``.
+
+A recurring, strong invariant used here is *scale invariance*: integrating the
+linear problem ``dy/dt = -y / tau`` with units (mV, ms) must give a mantissa
+identical to the dimensionless version (with the same RNG seed for SDEs), because
+units only rescale the algebra. This exercises every method's unit handling.
+"""
+
+import math
+
+import brainstate
+import brainunit as u
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import braintools
+
+
+# ===========================================================================
+# ODE: Ralston methods (previously untested) + order checks
+# ===========================================================================
+def _linear_one_step_err(method, dt, a=-1.3, y0=1.0):
+    def f(y, t):
+        return a * y
+
+    with brainstate.environ.context(dt=dt):
+        y1 = method(f, y0, 0.0)
+    return abs(float(y1) - y0 * math.exp(a * dt))
+
+
+def test_ralston2_is_second_order():
+    e1 = _linear_one_step_err(braintools.quad.ode_ralston2_step, 0.1)
+    e2 = _linear_one_step_err(braintools.quad.ode_ralston2_step, 0.05)
+    # 2nd order local error ~ dt^3; halving dt reduces error by ~8x (allow margin)
+    assert e2 < e1 / 4.0
+
+
+def test_ralston3_is_third_order():
+    e1 = _linear_one_step_err(braintools.quad.ode_ralston3_step, 0.1)
+    e2 = _linear_one_step_err(braintools.quad.ode_ralston3_step, 0.05)
+    assert e2 < e1 / 8.0
+
+
+def test_ralston3_equals_rk23_third_order_solution():
+    # The Ralston RK3 tableau equals the 3rd-order solution of Bogacki-Shampine.
+    def f(y, t):
+        return -1.3 * y
+
+    with brainstate.environ.context(dt=0.1):
+        r3 = braintools.quad.ode_ralston3_step(f, 1.0, 0.0)
+        r23 = braintools.quad.ode_rk23_step(f, 1.0, 0.0)
+    assert np.allclose(r3, r23)
+
+
+def test_dopri8_return_error_is_small_and_finite():
+    def f(y, t):
+        return -1.0 * y
+
+    with brainstate.environ.context(dt=0.1):
+        y1, err = braintools.quad.ode_dopri8_step(f, 1.0, 0.0, return_error=True)
+    assert np.isfinite(float(y1)) and np.isfinite(float(err))
+    assert abs(float(err)) < 1e-6  # 8th order: tiny local error estimate
+
+
+# ===========================================================================
+# ODE: scale invariance across all deterministic methods
+# ===========================================================================
+ODE_METHODS = [
+    'ode_euler_step', 'ode_rk2_step', 'ode_rk3_step', 'ode_rk4_step',
+    'ode_midpoint_step', 'ode_heun_step', 'ode_rk4_38_step',
+    'ode_ralston2_step', 'ode_ralston3_step', 'ode_ssprk33_step',
+    'ode_rk45_step', 'ode_rk23_step', 'ode_dopri5_step', 'ode_rkf45_step',
+    'ode_dopri8_step', 'ode_expeuler_step',
+]
+
+
+@pytest.mark.parametrize('name', ODE_METHODS)
+def test_ode_unit_scale_invariance(name):
+    method = getattr(braintools.quad, name)
+
+    def f_dimless(y, t):
+        return -y / 10.0
+
+    def f_unit(v, t):
+        return -v / (10.0 * u.ms)
+
+    with brainstate.environ.context(dt=0.1):
+        yd = method(f_dimless, -65.0, 0.0)
+    with brainstate.environ.context(dt=0.1 * u.ms):
+        yu = method(f_unit, -65.0 * u.mV, 0.0 * u.ms)
+
+    assert u.get_unit(yu) == u.mV
+    assert np.allclose(u.get_mantissa(yu), float(yd), rtol=1e-6)
+
+
+# ===========================================================================
+# SDE: branch coverage (Stratonovich, invalid types) + scale invariance
+# ===========================================================================
+def test_milstein_stratonovich_differs_from_ito():
+    def df(y, t):
+        return 0.1 * y
+
+    def dg(y, t):
+        return 0.3 * y
+
+    with brainstate.environ.context(dt=0.05):
+        brainstate.random.seed(1)
+        mi = braintools.quad.sde_milstein_step(df, dg, 1.0, 0.0, sde_type='ito')
+        brainstate.random.seed(1)
+        ms = braintools.quad.sde_milstein_step(df, dg, 1.0, 0.0, sde_type='stra')
+    # Same noise, different Ito/Stratonovich correction -> different result
+    assert not np.allclose(mi, ms)
+
+
+def test_heun_stratonovich_runs():
+    def df(y, t):
+        return -0.5 * y
+
+    def dg(y, t):
+        return 0.2 * y
+
+    with brainstate.environ.context(dt=0.05):
+        y1 = braintools.quad.sde_heun_step(df, dg, 1.0, 0.0, sde_type='stra')
+    assert np.isfinite(float(y1))
+
+
+@pytest.mark.parametrize('name', ['sde_euler_step', 'sde_milstein_step', 'sde_heun_step'])
+def test_sde_invalid_type_raises(name):
+    method = getattr(braintools.quad, name)
+
+    def df(y, t):
+        return -y
+
+    def dg(y, t):
+        return 0.1
+
+    with brainstate.environ.context(dt=0.1):
+        with pytest.raises(AssertionError):
+            method(df, dg, 1.0, 0.0, sde_type='nonsense')
+
+
+SDE_METHODS = [
+    'sde_euler_step', 'sde_milstein_step', 'sde_heun_step',
+    'sde_tamed_euler_step', 'sde_implicit_euler_step',
+    'sde_srk2_step', 'sde_srk3_step', 'sde_srk4_step', 'sde_expeuler_step',
+]
+
+
+@pytest.mark.parametrize('name', SDE_METHODS)
+def test_sde_unit_scale_invariance(name):
+    method = getattr(braintools.quad, name)
+    sigma = 0.5
+
+    def df_dimless(y, t):
+        return -y / 10.0
+
+    def dg_dimless(y, t):
+        return sigma
+
+    def df_unit(v, t):
+        return -v / (10.0 * u.ms)
+
+    def dg_unit(v, t):
+        return sigma * u.mV / u.ms ** 0.5
+
+    brainstate.random.seed(42)
+    with brainstate.environ.context(dt=0.1):
+        yd = method(df_dimless, dg_dimless, -65.0, 0.0)
+    brainstate.random.seed(42)
+    with brainstate.environ.context(dt=0.1 * u.ms):
+        yu = method(df_unit, dg_unit, -65.0 * u.mV, 0.0 * u.ms)
+
+    assert u.get_unit(yu) == u.mV
+    assert np.allclose(u.get_mantissa(yu), float(yd), rtol=1e-5)
+
+
+def test_sde_expeuler_diffusion_unit_mismatch_raises():
+    # Drift has unit mV/ms (state mV); diffusion with a wrong unit must be caught.
+    def df(v, t):
+        return -v / (10.0 * u.ms)
+
+    def dg(v, t):
+        return 0.5 * u.mV  # wrong: should be mV / sqrt(ms)
+
+    with brainstate.environ.context(dt=0.1 * u.ms):
+        with pytest.raises(ValueError):
+            braintools.quad.sde_expeuler_step(df, dg, -65.0 * u.mV, 0.0 * u.ms)
+
+
+def test_implicit_euler_converges_for_contractive_drift():
+    # Picard iteration converges when the drift is contractive (|a*dt| < 1).
+    a = -2.0
+
+    def df(y, t):
+        return a * y
+
+    def dg(y, t):
+        return 0.0
+
+    dt = 0.1
+    with brainstate.environ.context(dt=dt):
+        y1 = braintools.quad.sde_implicit_euler_step(df, dg, 1.0, 0.0, max_iter=60)
+    assert np.allclose(float(y1), 1.0 / (1.0 - a * dt), rtol=1e-4)
+
+
+# ===========================================================================
+# IMEX: scale invariance + structure
+# ===========================================================================
+def test_imex_euler_unit_scale_invariance():
+    def fe_d(y, t):
+        return -y / 50.0
+
+    def fi_d(y, t):
+        return -y / 10.0
+
+    def fe_u(v, t):
+        return -v / (50.0 * u.ms)
+
+    def fi_u(v, t):
+        return -v / (10.0 * u.ms)
+
+    with brainstate.environ.context(dt=0.1):
+        yd = braintools.quad.imex_euler_step(fe_d, fi_d, -65.0, 0.0, max_iter=10)
+    with brainstate.environ.context(dt=0.1 * u.ms):
+        yu = braintools.quad.imex_euler_step(fe_u, fi_u, -65.0 * u.mV, 0.0 * u.ms, max_iter=10)
+    assert u.get_unit(yu) == u.mV
+    assert np.allclose(u.get_mantissa(yu), float(yd), rtol=1e-6)
+
+
+def test_imex_ars222_and_cnab_with_units_finite():
+    def fe(v, t):
+        return (-65.0 * u.mV) / (20.0 * u.ms)
+
+    def fi(v, t):
+        return -v / (20.0 * u.ms)
+
+    v = -60.0 * u.mV
+    with brainstate.environ.context(dt=0.1 * u.ms):
+        v_ars = braintools.quad.imex_ars222_step(fe, fi, v, 0.0 * u.ms, max_iter=5)
+        v_cnab = braintools.quad.imex_cnab_step(fe, fi, v, v, 0.0 * u.ms, max_iter=5)
+    assert u.get_unit(v_ars) == u.mV and np.isfinite(u.get_mantissa(v_ars))
+    assert u.get_unit(v_cnab) == u.mV and np.isfinite(u.get_mantissa(v_cnab))
+
+
+# ===========================================================================
+# DDE: all methods, reduction to ODE, units, multiple delays
+# ===========================================================================
+DDE_METHODS = [
+    'dde_euler_step', 'dde_heun_step', 'dde_rk4_step',
+    'dde_euler_pc_step', 'dde_heun_pc_step',
+]
+
+
+@pytest.mark.parametrize('name', DDE_METHODS)
+def test_dde_independent_of_history_when_delay_unused(name):
+    # If f ignores the delayed term, the result must not depend on the history
+    # values: history may only influence the output through f's delayed argument.
+    method = getattr(braintools.quad, name)
+
+    def f_dde(t, y, y_delayed):
+        return -y  # ignores y_delayed
+
+    def hist_a(t_past):
+        return 123.0
+
+    def hist_b(t_past):
+        return -999.0
+
+    with brainstate.environ.context(dt=0.05):
+        ya = method(f_dde, 1.0, 0.0, hist_a, 0.5)
+        yb = method(f_dde, 1.0, 0.0, hist_b, 0.5)
+    assert np.isfinite(float(ya))
+    assert np.allclose(float(ya), float(yb))
+
+
+def test_dde_euler_matches_explicit_euler_when_delay_unused():
+    # The plain forward-Euler DDE predictor (no corrector) reduces exactly to the
+    # explicit ODE Euler step when f ignores the delayed term.
+    def f_dde(t, y, y_delayed):
+        return -y
+
+    def f_ode(y, t):
+        return -y
+
+    def history_fn(t_past):
+        return 123.0
+
+    with brainstate.environ.context(dt=0.05):
+        y_dde = braintools.quad.dde_euler_step(f_dde, 1.0, 0.0, history_fn, 0.5)
+        y_euler = braintools.quad.ode_euler_step(f_ode, 1.0, 0.0)
+    assert np.allclose(float(y_dde), float(y_euler))
+
+
+def test_dde_euler_with_units():
+    tau = 10.0 * u.ms
+
+    def f(t, y, y_delayed):
+        return (-y + y_delayed) / tau
+
+    def history_fn(t_past):
+        return -65.0 * u.mV
+
+    with brainstate.environ.context(dt=0.1 * u.ms):
+        v1 = braintools.quad.dde_euler_step(f, -65.0 * u.mV, 0.0 * u.ms, history_fn, 1.0 * u.ms)
+    assert u.get_unit(v1) == u.mV
+    assert np.isfinite(u.get_mantissa(v1))
+
+
+def test_dde_multiple_delays_and_pytree():
+    def f(t, y, yd1, yd2):
+        return jnp.tanh(yd1) + 0.5 * jnp.sin(yd2) - y
+
+    def history_fn(t_past):
+        return jnp.array([0.1, 0.2])
+
+    with brainstate.environ.context(dt=0.05):
+        y1 = braintools.quad.dde_rk4_step(
+            f, jnp.array([0.1, 0.2]), 0.0, history_fn, [0.5, 1.0]
+        )
+    assert y1.shape == (2,)
+    assert np.all(np.isfinite(np.asarray(y1)))
+
+
+def test_dde_pc_iterations_change_result():
+    # More corrector iterations should change (refine) the predictor-corrector result.
+    def f(t, y, y_delayed):
+        return -3.0 * y + 0.5 * y_delayed
+
+    def history_fn(t_past):
+        return 1.0
+
+    with brainstate.environ.context(dt=0.1):
+        y1 = braintools.quad.dde_euler_pc_step(f, 1.0, 0.0, history_fn, 0.5, max_iter=1)
+        y5 = braintools.quad.dde_euler_pc_step(f, 1.0, 0.0, history_fn, 0.5, max_iter=5)
+    assert not np.allclose(y1, y5)
+
+
+@pytest.mark.parametrize('name', ['dde_euler_pc_step', 'dde_heun_pc_step'])
+def test_dde_pc_accepts_list_of_delays(name):
+    # The predictor-corrector methods must accept multiple delays passed as a list,
+    # not only a single scalar delay.
+    method = getattr(braintools.quad, name)
+
+    def f(t, y, yd1, yd2):
+        return -y + 0.3 * yd1 + 0.2 * yd2
+
+    def history_fn(t_past):
+        return 1.0
+
+    with brainstate.environ.context(dt=0.1):
+        y_list = method(f, 1.0, 0.0, history_fn, [0.5, 1.0], max_iter=3)
+    assert np.isfinite(float(y_list))

--- a/braintools/quad/_quad_regression_test.py
+++ b/braintools/quad/_quad_regression_test.py
@@ -1,0 +1,214 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Regression tests for bugs found in the 2026-06-18 ``braintools.quad`` audit.
+
+Each test here reproduces a specific confirmed bug and asserts the *correct*
+behaviour, so it fails against the pre-fix code and passes after the fix.
+"""
+
+import math
+
+import brainstate
+import brainunit as u
+import numpy as np
+
+import braintools
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: ode_expeuler_step divided by the Jacobian unit instead of the state
+# unit, raising "exprel requires a dimensionless x" for unitful states.
+# Exponential Euler is exact for linear ODEs: y1 = y0 * exp(A*dt).
+# ---------------------------------------------------------------------------
+def test_ode_expeuler_step_with_units():
+    tau = 10.0 * u.ms
+
+    def f(v, t):
+        return -v / tau
+
+    v0 = -65.0 * u.mV
+    with brainstate.environ.context(dt=0.1 * u.ms):
+        v1 = braintools.quad.ode_expeuler_step(f, v0, 0.0 * u.ms)
+
+    expected = -65.0 * math.exp(-0.01)  # A*dt = -(1/10ms)*0.1ms = -0.01
+    assert u.get_unit(v1) == u.mV
+    assert np.allclose(u.get_mantissa(v1), expected, rtol=1e-6)
+
+
+def test_ode_expeuler_step_dimensionless_unchanged():
+    # Guard: the fix must not change the dimensionless result.
+    def f(x, t):
+        return -x
+
+    with brainstate.environ.context(dt=0.1):
+        x1 = braintools.quad.ode_expeuler_step(f, 1.0, 0.0)
+    assert np.allclose(x1, math.exp(-0.1), rtol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 + 3: sde_expeuler_step used randn_like(args[0]) (crashes with no extra
+# args) and the wrong unit. With zero diffusion it must equal exp-Euler drift.
+# ---------------------------------------------------------------------------
+def test_sde_expeuler_step_no_extra_args():
+    def df(x, t):
+        return -x
+
+    def dg(x, t):
+        return 0.0
+
+    with brainstate.environ.context(dt=0.1):
+        x1 = braintools.quad.sde_expeuler_step(df, dg, 1.0, 0.0)
+    # Zero diffusion -> deterministic exp-Euler drift = exp(-0.1)
+    assert np.allclose(x1, math.exp(-0.1), rtol=1e-6)
+
+
+def test_sde_expeuler_step_with_units():
+    tau = 10.0 * u.ms
+
+    def df(v, t):
+        return -v / tau
+
+    def dg(v, t):
+        return 0.0 * u.mV / u.ms ** 0.5
+
+    v0 = -65.0 * u.mV
+    with brainstate.environ.context(dt=0.1 * u.ms):
+        v1 = braintools.quad.sde_expeuler_step(df, dg, v0, 0.0 * u.ms)
+    assert u.get_unit(v1) == u.mV
+    assert np.allclose(u.get_mantissa(v1), -65.0 * math.exp(-0.01), rtol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Bug 4: sde_euler_step used jnp.sqrt(dt), which rejects unitful dt.
+# With zero diffusion the step is deterministic Euler.
+# ---------------------------------------------------------------------------
+def test_sde_euler_step_with_units():
+    tau = 10.0 * u.ms
+
+    def df(v, t):
+        return -v / tau
+
+    def dg(v, t):
+        return 0.0 * u.mV / u.ms ** 0.5
+
+    v0 = -65.0 * u.mV
+    with brainstate.environ.context(dt=0.1 * u.ms):
+        v1 = braintools.quad.sde_euler_step(df, dg, v0, 0.0 * u.ms)
+    expected = -65.0 + (65.0 / 10.0) * 0.1  # v0 + (-v0/tau)*dt
+    assert u.get_unit(v1) == u.mV
+    assert np.allclose(u.get_mantissa(v1), expected, rtol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Bug 5: sde_tamed_euler_step added a dimensionless 1 to a unitful dt*|f|.
+# ---------------------------------------------------------------------------
+def test_sde_tamed_euler_step_with_units():
+    tau = 10.0 * u.ms
+
+    def df(v, t):
+        return -v / tau
+
+    def dg(v, t):
+        return 0.0 * u.mV / u.ms ** 0.5
+
+    v0 = -65.0 * u.mV
+    dt = 0.1
+    with brainstate.environ.context(dt=dt * u.ms):
+        v1 = braintools.quad.sde_tamed_euler_step(df, dg, v0, 0.0 * u.ms)
+    f_val = 65.0 / 10.0  # mantissa of -v0/tau in mV/ms
+    tamed = f_val / (1.0 + dt * abs(f_val))
+    expected = -65.0 + tamed * dt
+    assert u.get_unit(v1) == u.mV
+    assert np.allclose(u.get_mantissa(v1), expected, rtol=1e-6)
+
+
+def test_sde_tamed_euler_step_dimensionless_unchanged():
+    # Guard: dimensionless taming result must be unchanged by the fix.
+    def df(y, t):
+        return y ** 3
+
+    def dg(y, t):
+        return 0.0
+
+    y0 = 10.0
+    dt = 0.1
+    with brainstate.environ.context(dt=dt):
+        y1 = braintools.quad.sde_tamed_euler_step(df, dg, y0, 0.0)
+    f_val = y0 ** 3
+    expected = y0 + (f_val / (1.0 + dt * abs(f_val))) * dt
+    assert np.allclose(y1, expected, rtol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Bug 14: the primary (propagated) solution of an embedded method must be
+# identical whether or not the error estimate is requested. This characterises
+# the FSAL refactor of ode_dopri5_step (the extra stage must not change y).
+# ---------------------------------------------------------------------------
+def test_embedded_primary_matches_return_error_branch():
+    a = -0.9
+
+    def f(y, t):
+        return a * y
+
+    methods = [
+        braintools.quad.ode_rk45_step,
+        braintools.quad.ode_dopri5_step,
+        braintools.quad.ode_rkf45_step,
+        braintools.quad.ode_rk23_step,
+        braintools.quad.ode_dopri8_step,
+    ]
+    with brainstate.environ.context(dt=0.1):
+        for fn in methods:
+            y_plain = fn(f, 1.0, 0.0)
+            y_err, _ = fn(f, 1.0, 0.0, return_error=True)
+            assert np.allclose(y_plain, y_err), fn.__name__
+
+
+# ---------------------------------------------------------------------------
+# Bug 15: a disallowed (non-float) input must raise a clean ValueError, not an
+# AttributeError while formatting the message (Python scalars have no .dtype).
+# ---------------------------------------------------------------------------
+def test_ode_expeuler_step_rejects_integer_scalar():
+    def f(x, t):
+        return -x
+
+    with brainstate.environ.context(dt=0.1):
+        try:
+            braintools.quad.ode_expeuler_step(f, 1, 0.0)  # python int
+        except ValueError:
+            pass
+        except Exception as e:  # pragma: no cover - explicit failure path
+            raise AssertionError(f"expected ValueError, got {type(e).__name__}: {e}")
+        else:
+            raise AssertionError("expected ValueError for integer input")
+
+
+def test_sde_expeuler_step_rejects_integer_scalar():
+    def df(x, t):
+        return -x
+
+    def dg(x, t):
+        return 0.0
+
+    with brainstate.environ.context(dt=0.1):
+        try:
+            braintools.quad.sde_expeuler_step(df, dg, 1, 0.0)  # python int
+        except ValueError:
+            pass
+        except Exception as e:  # pragma: no cover - explicit failure path
+            raise AssertionError(f"expected ValueError, got {type(e).__name__}: {e}")
+        else:
+            raise AssertionError("expected ValueError for integer input")

--- a/braintools/quad/_sde_integrator.py
+++ b/braintools/quad/_sde_integrator.py
@@ -114,7 +114,7 @@ def sde_euler_step(
     assert sde_type in ['ito']
 
     dt = brainstate.environ.get_dt()
-    dt_sqrt = jnp.sqrt(dt)
+    dt_sqrt = u.math.sqrt(dt)
     y_bars = tree_map(
         lambda y0, drift, diffusion: y0 + drift * dt + diffusion * randn_like(y0) * dt_sqrt,
         y,
@@ -235,14 +235,13 @@ def sde_expeuler_step(
     t : float or brainunit.Quantity
         Current time.
     *args
-        Extra arguments forwarded to ``df`` and ``dg``. The first extra argument
-        is used solely to determine the shape for ``random.randn_like`` when
-        sampling the diffusion noise.
+        Extra arguments forwarded to ``df`` and ``dg``.
 
     Returns
     -------
     PyTree
-        The updated state ``y_{n+1}`` with the same structure as ``y``.
+        The updated state ``y_{n+1}`` with the same structure as ``y``. The
+        Brownian increment is sampled with the shape of ``y``.
 
     See Also
     --------
@@ -261,18 +260,20 @@ def sde_expeuler_step(
     if u.math.get_dtype(y) not in [jnp.float32, jnp.float64, jnp.float16, jnp.bfloat16]:
         raise ValueError(
             f'The input data type should be float64, float32, float16, or bfloat16 '
-            f'when using Exponential Euler method. But we got {y.dtype}.'
+            f'when using Exponential Euler method. But we got {u.math.get_dtype(y)}.'
         )
 
     # drift
     dt = brainstate.environ.get('dt')
     linear, derivative = brainstate.transform.vector_grad(df, argnums=0, return_value=True)(y, t, *args, **kwargs)
-    linear = u.Quantity(u.get_mantissa(linear), u.get_unit(derivative) / u.get_unit(linear))
+    # Divide by the *state* unit, not the Jacobian's own unit, so ``dt * linear``
+    # stays dimensionless for ``u.math.exprel`` (see ``ode_expeuler_step``).
+    linear = u.Quantity(u.get_mantissa(linear), u.get_unit(derivative) / u.get_unit(y))
     phi = u.math.exprel(dt * linear)
     x_next = y + dt * phi * derivative
 
-    # diffusion
-    diffusion_part = dg(y, t, *args, **kwargs) * u.math.sqrt(dt) * randn_like(args[0])
+    # diffusion: sample the Brownian increment with the shape of the state ``y``
+    diffusion_part = dg(y, t, *args, **kwargs) * u.math.sqrt(dt) * randn_like(y)
     if u.get_dim(x_next) != u.get_dim(diffusion_part):
         drift_unit = u.get_unit(x_next)
         time_unit = u.get_unit(dt)
@@ -407,7 +408,10 @@ def sde_tamed_euler_step(
     f0 = df(y, t, *args, **kwargs)
     g0 = dg(y, t, *args, **kwargs)
 
-    f_tamed = tree_map(lambda a: a / (1.0 + dt * u.math.abs(a)), f0)
+    # The taming factor ``1 / (1 + dt*|f|)`` must be a pure number. ``dt*|f|``
+    # carries the state's unit, so take its mantissa; this reduces exactly to the
+    # classical scheme when the state is dimensionless.
+    f_tamed = tree_map(lambda a: a / (1.0 + u.get_mantissa(dt * u.math.abs(a))), f0)
     y_next = tree_map(
         lambda y0, a, b: y0 + a * dt + b * randn_like(y0) * dt_sqrt,
         y, f_tamed, g0
@@ -452,8 +456,12 @@ def sde_implicit_euler_step(
 
     Notes
     -----
-    - Uses a simple Picard iteration; for stiff problems increase ``max_iter``
-      or provide a more robust nonlinear solver.
+    - The implicit drift stage is solved by a simple Picard (fixed-point)
+      iteration. This iteration converges only when the drift is contractive
+      over the step, i.e. roughly ``|∂f/∂y| dt < 1``. For stiff problems
+      (``|∂f/∂y| dt >= 1``) it *diverges* regardless of ``max_iter``; reduce
+      ``dt`` or supply a true nonlinear solver (e.g. Newton) instead. Increasing
+      ``max_iter`` only refines an already-converging iteration.
     - Diffusion is treated explicitly with ``g(y_n, t_n) dW``.
     """
     assert callable(df), 'The drift function should be callable.'

--- a/braintools/quad/_sde_integrator_test.py
+++ b/braintools/quad/_sde_integrator_test.py
@@ -158,8 +158,15 @@ def test_tamed_euler_bounds_superlinear_no_noise():
 
 
 def test_implicit_euler_linear_no_noise():
-    # Implicit Euler for stiff linear drift f(y)=a*y, a<<0, without noise
-    a = -50.0
+    # Implicit Euler for linear drift f(y)=a*y, without noise.
+    #
+    # ``sde_implicit_euler_step`` solves the implicit stage y1 = y0 + dt*a*y1 by
+    # fixed-point (Picard) iteration y1^{k+1} = y0 + dt*a*y1^{k}. This iteration is
+    # a contraction iff |dt*a| < 1, so it converges only for non-stiff coefficients.
+    # We therefore use a = -2 (|dt*a| = 0.2 < 1); a stiff a (e.g. -50) would make
+    # the iteration DIVERGE away from the exact solution, no matter how large
+    # max_iter is -- see the docstring note on ``sde_implicit_euler_step``.
+    a = -2.0
 
     def df(y, t):
         return a * y
@@ -174,7 +181,7 @@ def test_implicit_euler_linear_no_noise():
 
     # Exact implicit Euler formula: y1 = y0 / (1 - a*dt)
     y_exact = y0 / (1.0 - a * dt)
-    # assert np.allclose(y1, y_exact, rtol=1e-3, atol=1e-6)
+    assert np.allclose(y1, y_exact, rtol=1e-3, atol=1e-6)
 
 
 def test_sde_euler_pytree_structure():

--- a/docs/apis/quad.rst
+++ b/docs/apis/quad.rst
@@ -78,3 +78,21 @@ processes.
     sde_srk4_step
 
 
+DDE Numerical Integrators
+-------------------------
+
+Steppers for delay differential equations, where the right-hand side depends on
+one or more delayed states ``y(t - τ)`` supplied by a user history function.
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+    :template: classtemplate.rst
+
+    dde_euler_step
+    dde_heun_step
+    dde_rk4_step
+    dde_euler_pc_step
+    dde_heun_pc_step
+
+

--- a/docs/braintools-quad-issues-found-20260618.md
+++ b/docs/braintools-quad-issues-found-20260618.md
@@ -1,0 +1,310 @@
+# `braintools.quad` — Issues Found and Proposed Solutions (2026-06-18)
+
+Audit of the `braintools/quad/` module (ODE / SDE / DDE / IMEX one-step
+integrators) and its documentation, performed as a senior Python architect /
+JAX expert / BrainX developer.
+
+Scope reviewed:
+
+- `braintools/quad/__init__.py` (public API + module docstring)
+- `braintools/quad/_ode_integrator.py`
+- `braintools/quad/_sde_integrator.py`
+- `braintools/quad/_dde_integrator.py`
+- `braintools/quad/_imex_integrator.py`
+- Existing tests (`*_test.py`)
+- `docs/apis/quad.rst`, `docs/quad/*` (index + notebooks)
+
+Every **correctness** finding below was reproduced empirically against
+`jax 0.10.1`, `brainunit 0.5.1`, `brainstate 0.5.0` before being recorded.
+
+Numerical method correctness was cross-checked against the standard Butcher
+tableaux: Euler, RK2 (Heun), RK3 (Kutta), RK4, RK4 3/8-rule, Cash–Karp 4(5),
+Bogacki–Shampine 2(3)/3(2), Dormand–Prince 5(4) and 8(7) (DOP853), RK–Fehlberg
+4(5), SSPRK(3,3), Ralston RK2/RK3, and ARS(2,2,2). **All tableaux are
+implemented correctly.** The bugs are concentrated in unit handling, noise
+sampling, and documentation.
+
+---
+
+## Severity summary
+
+| #  | Severity | Location | One-line |
+|----|----------|----------|----------|
+| 1  | High | `_ode_integrator.py:305` | `ode_expeuler_step` divides by Jacobian unit instead of state unit → crashes with units |
+| 2  | High | `_sde_integrator.py:270` | `sde_expeuler_step` same unit bug |
+| 3  | High | `_sde_integrator.py:275` | `sde_expeuler_step` samples noise from `args[0]` → `IndexError`/wrong shape |
+| 4  | High | `_sde_integrator.py:117` | `sde_euler_step` uses `jnp.sqrt(dt)` → crashes for unitful `dt` |
+| 5  | High | `_sde_integrator.py:410` | `sde_tamed_euler_step` taming term is dimensionally inconsistent → crashes with units |
+| 6  | Medium | `_ode_integrator.py:267-279` | `ode_expeuler_step` docstring: full-width comma, wrong name, SDE-only text |
+| 7  | Medium | `__init__.py:129` | `ode_heun_step` example mislabeled "second-order" (it is third-order) |
+| 8  | Medium | `__init__.py:191` | SDE example calls `sde_srk3_step` not imported in that block |
+| 9  | Medium | `__init__.py:197-207` | `sde_expeuler_step` example uses a non-existent signature |
+| 10 | Medium | `__init__.py:246` | `imex_cnab_step` example omits the required `y_prev` argument |
+| 11 | Medium | `__init__.py:267-274` | DDE history-init loop iterates an empty `deque` → never initializes |
+| 12 | Medium | `_dde_integrator.py:106` | `dde_euler_step` docstring example uses `delay=` (param is `delays`) |
+| 13 | Medium | `docs/apis/quad.rst` | DDE integrators entirely missing from the API reference |
+| 14 | Low | `_ode_integrator.py:690-698` | `ode_dopri5_step` computes an extra stage even when `return_error=False` |
+| 15 | Low | `_ode_integrator.py:301`, `_sde_integrator.py:264` | Exp-Euler dtype error message uses `y.dtype`, fails for Python `float` |
+| 16 | Low | `_sde_integrator_test.py:177` | Dead test: the only assertion is commented out |
+| 17 | Low | several | `Callable[[A, B, ...], R]` alias mixes positional types with `...` (cosmetic) |
+
+---
+
+## High-severity correctness bugs
+
+### 1 & 2 — Exponential Euler divides by the wrong unit
+
+`ode_expeuler_step` (`_ode_integrator.py:305`) and `sde_expeuler_step`
+(`_sde_integrator.py:270`) both contain:
+
+```python
+linear, derivative = brainstate.transform.vector_grad(f, argnums=0, return_value=True)(y, t, *args, **kwargs)
+linear = u.Quantity(u.get_mantissa(linear), u.get_unit(derivative) / u.get_unit(linear))
+phi = u.math.exprel(dt * linear)
+```
+
+`vector_grad` returns the diagonal Jacobian `J = ∂f/∂y`. Physically `J` has unit
+`unit(f)/unit(y) = [X]/[T]/[X] = 1/[T]`, so `dt * J` is dimensionless and
+`exprel` is well-defined. The code rebuilds `linear` with unit
+`unit(derivative)/unit(linear) = ([X]/[T]) / (1/[T]) = [X]` — i.e. it assigns the
+**state** unit to the linear coefficient. `dt * linear` then has unit `[T]·[X]`
+and `u.math.exprel` rejects it.
+
+This is exactly the failure mode that the canonical `brainstate.nn.exp_euler_step`
+documents in an inline comment ("Divide by the *state* unit, not the Jacobian
+unit … `u.math.exprel` in saiunit>=0.4.0 rejects"). The braintools port took the
+wrong unit.
+
+**Reproduction**
+
+```python
+def f(v, t):
+    return (-v) / (10.0 * u.ms)
+with brainstate.environ.context(dt=0.1 * u.ms):
+    braintools.quad.ode_expeuler_step(f, -65.0 * u.mV, 0.0 * u.ms)
+# TypeError: exprel requires a dimensionless "x" ... Got Quantity(unit=mV, ...)
+```
+
+The existing tests never exercise units, so the bug is invisible to them.
+
+**Fix** — divide by the unit of the state `y`:
+
+```python
+linear = u.Quantity(u.get_mantissa(linear), u.get_unit(derivative) / u.get_unit(y))
+```
+
+Verified: with the fix the unitful result equals the dimensionless result times
+the unit (`-64.35324 mV`), and matches `ode_euler_step`/`ode_rk4_step`.
+
+### 3 — `sde_expeuler_step` samples noise from `args[0]`
+
+`_sde_integrator.py:275`:
+
+```python
+diffusion_part = dg(y, t, *args, **kwargs) * u.math.sqrt(dt) * randn_like(args[0])
+```
+
+The Brownian increment shape is taken from the **first extra positional
+argument** rather than from the state `y`. Consequences:
+
+- Calling `sde_expeuler_step(df, dg, y, t)` with no extra args raises
+  `IndexError: tuple index out of range`.
+- When extra args *are* supplied they are also forwarded to `df`/`dg`, so the
+  argument is doubly-overloaded; if `args[0]` is not shaped like `y` the noise is
+  silently the wrong shape.
+
+Every other SDE stepper samples noise from the state (`randn_like(y)` /
+`randn_like(y0)`).
+
+**Fix** — sample from the state and drop the `args[0]` dependency:
+
+```python
+diffusion_part = dg(y, t, *args, **kwargs) * u.math.sqrt(dt) * randn_like(y)
+```
+
+and remove the docstring sentence claiming the first extra argument fixes the
+noise shape.
+
+### 4 — `sde_euler_step` uses `jnp.sqrt` on a unitful `dt`
+
+`_sde_integrator.py:117`:
+
+```python
+dt_sqrt = jnp.sqrt(dt)            # all sibling steppers use u.math.sqrt(dt)
+```
+
+`jnp.sqrt` cannot consume a `saiunit.Quantity`:
+
+```python
+# TypeError: sqrt requires ndarray or scalar arguments, got <class 'saiunit.Quantity'>
+```
+
+`sde_euler_step` is the headline SDE method and the one most likely to be called
+with a unitful `dt` (e.g. `0.1 * u.ms`). `sde_milstein_step` and the others use
+`u.math.sqrt` and work correctly.
+
+**Fix**
+
+```python
+dt_sqrt = u.math.sqrt(dt)
+```
+
+### 5 — `sde_tamed_euler_step` taming term is dimensionally inconsistent
+
+`_sde_integrator.py:410`:
+
+```python
+f_tamed = tree_map(lambda a: a / (1.0 + dt * u.math.abs(a)), f0)
+```
+
+`dt * |f|` has unit `[T]·[X]/[T] = [X]` (the state's unit), so `1.0 + dt*|f|`
+adds a dimensionless `1` to a unitful quantity → `UnitMismatchError`. The taming
+factor must be a pure number. The classical tamed-Euler scheme (Hutzenthaler,
+Jentzen & Kloeden 2012) is implicitly written for dimensionless states.
+
+**Fix** — form the taming factor from the dimensionless magnitude of the drift
+increment, which reduces *exactly* to the original expression when the state is
+dimensionless:
+
+```python
+f_tamed = tree_map(lambda a: a / (1.0 + u.get_mantissa(dt * u.math.abs(a))), f0)
+```
+
+Verified: dimensionless case reproduces `f/(1+dt|f|)` to full precision; unitful
+case integrates cleanly.
+
+---
+
+## Medium-severity documentation bugs
+
+### 6 — `ode_expeuler_step` docstring is corrupted
+
+`_ode_integrator.py:267-279`:
+
+```python
+>>> exp_euler_step(fun, x， 0.)      # full-width comma '，' → SyntaxError under doctest;
+                                     # also the wrong function name
+```
+
+The Examples block additionally references `diffusion_fn` (an SDE concept that
+does not apply to the ODE stepper) and shows no expected output. Rewrite using
+the real name `ode_expeuler_step`, an ASCII comma, a runnable example, and drop
+the diffusion text.
+
+### 7 — `ode_heun_step` mislabeled in the module docstring
+
+`__init__.py:129` lists `ode_heun_step` under the comment "Second-order
+methods". The function (and its own docstring) is Heun's **third-order** RK.
+Move it to the third-order group.
+
+### 8 — SDE example uses a name it never imports
+
+`__init__.py:159-191`: the import block pulls in
+`sde_euler_step, sde_milstein_step, sde_expeuler_step, sde_heun_step,
+sde_srk2_step, sde_tamed_euler_step` but the example then calls
+`sde_srk3_step`, producing a `NameError` if executed. Add `sde_srk3_step` to the
+import list (or drop the call).
+
+### 9 — `sde_expeuler_step` example uses a non-existent signature
+
+`__init__.py:197-207` calls
+`sde_expeuler_step(linear_drift, nonlinear_drift, diffusion, V, t)` as though the
+drift were split into linear/nonlinear parts. The real signature is
+`sde_expeuler_step(df, dg, y, t, *args)` with a single drift `df` linearized
+internally. Rewrite the example to `sde_expeuler_step(drift, diffusion, V, t)`.
+
+### 10 — `imex_cnab_step` example omits the required `y_prev`
+
+`__init__.py:246` calls `imex_cnab_step(f_explicit, f_implicit, V, t, ...)`, but
+CNAB is a *multistep* method whose signature is
+`imex_cnab_step(f_exp, f_imp, y, y_prev, t, *args)`. As written the call raises
+`TypeError` (missing `t`). Update the example to pass a previous state and note
+that CNAB needs two history points.
+
+### 11 — DDE history initialization loop never runs
+
+`__init__.py:267-274`:
+
+```python
+history = deque(maxlen=int(delay / bst.environ.get_dt()) + 1)
+...
+for i in range(len(history)):    # len(history) == 0 here → body never executes
+    history.append(y)
+```
+
+The `deque` is freshly created and therefore empty, so `range(len(history))` is
+empty and the history is never seeded. Iterate over the intended count
+(`history.maxlen`) instead.
+
+### 12 — `dde_euler_step` docstring example uses `delay=`
+
+`_dde_integrator.py:106`: `dde_euler_step(f, y, t, history_fn, delay=1.0)`. The
+parameter is named `delays`; `delay=` is swallowed by `**kwargs` and forwarded to
+`f`, while the required `delays` argument is missing → `TypeError`. Use
+`delays=1.0`.
+
+### 13 — DDE integrators missing from the API reference
+
+`docs/apis/quad.rst` documents ODE, IMEX and SDE steppers but has **no DDE
+section**, even though `dde_euler_step`, `dde_heun_step`, `dde_rk4_step`,
+`dde_euler_pc_step`, `dde_heun_pc_step` are all public (exported in `__all__`).
+Add a "DDE Numerical Integrators" autosummary block.
+
+---
+
+## Low-severity / robustness
+
+### 14 — `ode_dopri5_step` computes a redundant stage
+
+`_ode_integrator.py:690-708`: the 7th stage `y7`/`k7` is computed before the
+`return_error` check, and `y7` is byte-for-byte identical to `y5th` (both use the
+`b5` weights). When `return_error=False` the extra `tree_map` and `f` evaluation
+are dead work (XLA DCE hides this under `jit`, but eager calls pay for it). Use
+the FSAL property: compute `k7 = f(y5th, t+dt)` only inside the
+`return_error` branch.
+
+### 15 — Exp-Euler dtype error message crashes on Python floats
+
+`_ode_integrator.py:301` and `_sde_integrator.py:264` interpolate `{y.dtype}`
+into the `ValueError` message. If a disallowed input is a Python `float` (no
+`.dtype`), formatting the message itself raises `AttributeError`, masking the
+intended error. Use `u.math.get_dtype(y)`.
+
+### 16 — Dead test
+
+`_sde_integrator_test.py:160-177` (`test_implicit_euler_linear_no_noise`)
+computes `y_exact` but its only `assert` is commented out, so the test validates
+nothing. Replace with a real assertion (implicit Euler has the closed form
+`y1 = y0 / (1 - a·dt)`).
+
+### 17 — Cosmetic type alias
+
+`ODE = Callable[[brainstate.typing.PyTree, float | u.Quantity, ...], ...]` mixes
+explicit positional types with `...`, which is not valid `Callable` form for
+static checkers (it is accepted at runtime). Harmless; could be simplified to
+`Callable[..., brainstate.typing.PyTree]`.
+
+---
+
+## Method-correctness verification (no changes needed)
+
+For the record, these were checked digit-by-digit against published tableaux and
+found correct: `ode_euler/rk2/rk3/rk4/rk4_38`, `ode_midpoint`, `ode_heun` (Heun
+RK3), `ode_rk45` (Cash–Karp), `ode_rk23`/`ode_bs32` (Bogacki–Shampine),
+`ode_dopri5`, `ode_rkf45`, `ode_ssprk33`, `ode_ralston2/3`, `ode_dopri8`
+(DOP853 incl. embedded error), all `imex_*`, `sde_milstein` (derivative-free
+Platen), `sde_heun`, `sde_srk2/3/4`, and the DDE stage times. ODE/IMEX/DDE all
+integrate correctly with `brainunit` quantities.
+
+---
+
+## Remediation plan
+
+1. Fix bugs 1–5 (correctness) and 14–15 (robustness) in the three integrator
+   modules; tame on the mantissa for bug 5; sample noise from `y` for bug 3.
+2. Fix documentation bugs 6–13 (module docstrings, DDE docstring, `quad.rst`).
+3. Repair the dead test (16) and add comprehensive new tests covering: unitful
+   ODE/SDE exp-Euler, unitful `sde_euler`/`sde_tamed_euler`, `sde_expeuler`
+   no-arg call, embedded-error pairs, IMEX/DDE paths, and PyTree structure — to
+   exceed 90 % statement coverage of `braintools/quad/`.
+4. Leave 17 as a noted cosmetic item (no behavioral impact).


### PR DESCRIPTION
## Summary

Senior-architect / JAX-expert audit of `braintools/quad/` (ODE / SDE / DDE / IMEX one-step integrators) and its documentation. Every Butcher tableau was cross-checked and is **correct**; the defects are concentrated in **unit handling**, **noise sampling**, and **documentation**. Full report: `docs/braintools-quad-issues-found-20260618.md` (17 findings, severity-ranked, each correctness bug reproduced empirically before fixing).

## Correctness fixes (all crashed or misbehaved under `brainunit`)

| # | Function | Bug | Fix |
|---|----------|-----|-----|
| 1 | `ode_expeuler_step` | divided diagonal Jacobian by the Jacobian's *own* unit → `dt*A` not dimensionless → `exprel` rejects unitful states | divide by the **state** unit |
| 2 | `sde_expeuler_step` | same unit bug | divide by the state unit |
| 3 | `sde_expeuler_step` | sampled noise from `args[0]` → `IndexError`/wrong shape with no extra args | sample with the shape of `y` |
| 4 | `sde_euler_step` | `jnp.sqrt(dt)` crashed for unitful `dt` | `u.math.sqrt(dt)` |
| 5 | `sde_tamed_euler_step` | taming factor `1/(1+dt·|f|)` dimensionally inconsistent | take mantissa of `dt·|f|`; reduces exactly to the classical scheme when dimensionless |

Also: `*_expeuler_step` dtype-error message used `y.dtype` (absent on unitful `y`) → now `u.math.get_dtype(y)`.

## Performance

- `ode_dopri5_step`: exploit the **FSAL** property (`y7 == y5th`) to drop one redundant stage evaluation. `k7 = f(y5th, t+dt)` is now computed only when `return_error=True`. The returned primary is numerically identical, guarded by a regression test.

## Documentation

- Rewrote the corrupted `ode_expeuler_step` docstring (full-width comma `，`, wrong function name, irrelevant SDE-only text) with correct math, the unit contract, and runnable examples.
- Corrected `sde_implicit_euler_step` Notes: Picard iteration **diverges** for stiff problems regardless of `max_iter` — reduce `dt` or use a Newton solver.
- Made **all 9** module-docstring code blocks executable; fixed mislabeled method orders, missing imports, and unit typos. Added a DDE section to `docs/apis/quad.rst`.

## Tests

- New `_quad_regression_test.py` (reproductions for bugs 1–5) and `_quad_coverage_test.py` (branch / edge-case / **unit-scale-invariance**: a method on a unitful problem must yield a mantissa identical to its dimensionless counterpart, seeded for SDEs).
- Restored a dead implicit-Euler test whose assertion had been commented out because it used a *divergent* stiff coefficient; it now asserts convergence for a contractive coefficient.
- **`braintools/quad` branch coverage: 100%** (86 tests pass). The single defensive `else` in the DOP853 stage loop is unreachable for the fixed tableau and marked `# pragma: no cover`.

## Test plan

- [x] `pytest braintools/quad/` → 86 passed
- [x] Branch coverage 100% on all five `quad` source files
- [x] All 9 module-docstring code blocks execute
- [x] `import braintools` / `import braintools.quad` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)