### PR TITLE
fix(surrogate): correct gradient/function formulas, add correctness tests, align docs

### DIFF
--- a/braintools/surrogate/_base.py
+++ b/braintools/surrogate/_base.py
@@ -164,6 +164,25 @@ class Surrogate(PrettyObject):
     `surrogate_grad` method. This straight-through estimator approach enables
     gradient-based training of spiking neural networks.
 
+    Implementing ``surrogate_fun`` is **optional** -- it is used only for
+    visualization/analysis. Gradient-only surrogates (e.g. ``ReluGrad``,
+    ``GaussianGrad``, ``MultiGaussianGrad``, ``InvSquareGrad``, ``SlayerGrad``)
+    do not define it, so calling ``surrogate_fun`` on them raises
+    ``NotImplementedError``. When both are defined, ``surrogate_grad`` is the
+    exact derivative of ``surrogate_fun``.
+
+    The input ``x`` is expected to be a **dimensionless** array (typically the
+    membrane potential minus the threshold, in matching units). Passing a
+    unitful ``brainunit.Quantity`` is not supported by the underlying primitive.
+
+    Differentiating the output with respect to the **input** ``x`` yields the
+    surrogate gradient, as intended. Differentiating with respect to a
+    **surrogate parameter** (e.g. ``alpha``) returns the derivative of the
+    surrogate-gradient function w.r.t. that parameter (a side effect of the
+    custom JVP rule), *not* the mathematically-true ``0`` of the Heaviside
+    output -- so surrogate parameters cannot be trained as ordinary
+    ``ParamState`` weights through this output.
+
     """
     __module__ = 'braintools.surrogate'
 

--- a/braintools/surrogate/_correctness_test.py
+++ b/braintools/surrogate/_correctness_test.py
@@ -1,0 +1,388 @@
+# Copyright 2024 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+Correctness tests for ``braintools.surrogate``.
+
+Unlike ``_impl_test.py`` (which checks that backprop reproduces
+``surrogate_grad`` -- i.e. the *plumbing*), this module checks the surrogate
+*formulas* themselves against:
+
+* their documented mathematical definitions / closed-form references, and
+* the function/derivative consistency ``d/dx surrogate_fun == surrogate_grad``.
+
+These are the checks that catch a wrong ``surrogate_grad``/``surrogate_fun``
+formula -- the failure mode the self-referential suite cannot detect.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import braintools.surrogate as surrogate
+
+
+# ---------------------------------------------------------------------------
+# 1. Function / derivative consistency: d/dx surrogate_fun == surrogate_grad.
+#    Catches the Arctan, ERF, PiecewiseQuadratic, PiecewiseLeakyRelu and
+#    QPseudoSpike fun/grad mismatches.
+# ---------------------------------------------------------------------------
+
+# (label, surrogate-with-surrogate_fun). Only surrogates that implement
+# ``surrogate_fun`` are included.
+_FUN_SURROGATES = [
+    ('Sigmoid', surrogate.Sigmoid(alpha=4.0)),
+    ('Sigmoid(a=1)', surrogate.Sigmoid(alpha=1.0)),
+    ('PiecewiseQuadratic(a=0.5)', surrogate.PiecewiseQuadratic(alpha=0.5)),
+    ('PiecewiseQuadratic(a=1)', surrogate.PiecewiseQuadratic(alpha=1.0)),
+    ('PiecewiseQuadratic(a=2)', surrogate.PiecewiseQuadratic(alpha=2.0)),
+    ('PiecewiseExp', surrogate.PiecewiseExp(alpha=1.0)),
+    ('PiecewiseExp(a=2)', surrogate.PiecewiseExp(alpha=2.0)),
+    ('SoftSign', surrogate.SoftSign(alpha=2.0)),
+    ('Arctan(a=0.5)', surrogate.Arctan(alpha=0.5)),
+    ('Arctan(a=1)', surrogate.Arctan(alpha=1.0)),
+    ('Arctan(a=2)', surrogate.Arctan(alpha=2.0)),
+    ('NonzeroSignLog', surrogate.NonzeroSignLog(alpha=1.0)),
+    ('ERF(a=0.5)', surrogate.ERF(alpha=0.5)),
+    ('ERF(a=1)', surrogate.ERF(alpha=1.0)),
+    ('ERF(a=2)', surrogate.ERF(alpha=2.0)),
+    ('PiecewiseLeakyRelu', surrogate.PiecewiseLeakyRelu(c=0.01, w=1.0)),
+    ('PiecewiseLeakyRelu(w=2)', surrogate.PiecewiseLeakyRelu(c=0.05, w=2.0)),
+    ('SquarewaveFourierSeries', surrogate.SquarewaveFourierSeries(n=2, t_period=8.0)),
+    ('SquarewaveFourierSeries(n=3)', surrogate.SquarewaveFourierSeries(n=3, t_period=6.0)),
+    ('S2NN', surrogate.S2NN(alpha=4.0, beta=1.0)),
+    ('QPseudoSpike(a=0.5)', surrogate.QPseudoSpike(alpha=0.5)),
+    ('QPseudoSpike(a=1)', surrogate.QPseudoSpike(alpha=1.0)),
+    ('QPseudoSpike(a=2)', surrogate.QPseudoSpike(alpha=2.0)),
+    ('QPseudoSpike(a=3)', surrogate.QPseudoSpike(alpha=3.0)),
+    ('LeakyRelu', surrogate.LeakyRelu(alpha=0.1, beta=1.0)),
+    ('LogTailedRelu', surrogate.LogTailedRelu(alpha=0.1)),
+]
+
+
+@pytest.mark.parametrize("label, sg", _FUN_SURROGATES, ids=[s[0] for s in _FUN_SURROGATES])
+def test_surrogate_fun_derivative_matches_grad(label, sg):
+    # Avoid the exact piecewise break-points where the autodiff of a kink is
+    # ambiguous (e.g. |x| = 1/alpha, |x| = w, x in {0, 1}).
+    xs = jnp.linspace(-1.7, 1.7, 69) + 1e-3
+    auto = jax.vmap(jax.grad(sg.surrogate_fun))(xs)
+    manual = sg.surrogate_grad(xs)
+    assert jnp.all(jnp.isfinite(auto))
+    assert jnp.allclose(auto, manual, atol=1e-4, rtol=1e-4), label
+
+
+# ---------------------------------------------------------------------------
+# 2. Shape of the smooth surrogate function: a valid soft-Heaviside passes
+#    through 0.5 at the threshold and is monotonically increasing.  Catches the
+#    ERF (decreasing) and Arctan (out-of-range) bugs.
+# ---------------------------------------------------------------------------
+
+# CDF-like surrogates: smooth Heaviside passing through (0, 0.5).
+_HALF_AT_THRESHOLD = [
+    surrogate.Sigmoid(alpha=4.0),
+    surrogate.PiecewiseExp(alpha=1.0),
+    surrogate.SoftSign(alpha=2.0),
+    surrogate.Arctan(alpha=1.0),
+    surrogate.ERF(alpha=1.0),
+    surrogate.PiecewiseLeakyRelu(c=0.01, w=1.0),
+]
+
+# Monotonically increasing surrogate functions (CDF-like plus the relu-like
+# LeakyRelu, which passes through the origin rather than (0, 0.5)).
+_MONOTONE = _HALF_AT_THRESHOLD + [surrogate.LeakyRelu(alpha=0.1, beta=1.0)]
+
+
+@pytest.mark.parametrize("sg", _HALF_AT_THRESHOLD, ids=lambda s: type(s).__name__)
+def test_surrogate_fun_half_at_threshold(sg):
+    assert np.allclose(float(sg.surrogate_fun(jnp.array(0.0))), 0.5, atol=1e-6)
+
+
+@pytest.mark.parametrize("sg", _MONOTONE, ids=lambda s: type(s).__name__)
+def test_surrogate_fun_monotone_increasing(sg):
+    xs = jnp.linspace(-3, 3, 121)
+    z = sg.surrogate_fun(xs)
+    assert bool(jnp.all(jnp.diff(z) >= -1e-6))
+
+
+@pytest.mark.parametrize(
+    "sg",
+    [surrogate.Sigmoid(alpha=4.0), surrogate.Arctan(alpha=1.0), surrogate.ERF(alpha=1.0)],
+    ids=lambda s: type(s).__name__,
+)
+def test_bounded_surrogate_fun_in_unit_interval(sg):
+    # Sigmoid/Arctan/ERF smooth functions are CDFs: they must stay within [0, 1].
+    xs = jnp.linspace(-50, 50, 401)
+    z = sg.surrogate_fun(xs)
+    assert float(jnp.min(z)) >= -1e-6
+    assert float(jnp.max(z)) <= 1.0 + 1e-6
+
+
+def test_arctan_fun_not_arctan2_regression():
+    # Regression for the arctan2 misuse: the value at x=2, alpha=1 must be
+    # arctan(pi)/pi + 0.5, NOT arctan(1.0) + 0.5.
+    sg = surrogate.Arctan(alpha=1.0)
+    got = float(sg.surrogate_fun(jnp.array(2.0)))
+    expected = float(jnp.arctan(jnp.pi) / jnp.pi + 0.5)
+    assert np.allclose(got, expected, atol=1e-6)
+    assert got <= 1.0  # the buggy version returned ~1.6
+
+
+# ---------------------------------------------------------------------------
+# 3. Reference gradients: surrogate_grad against independent closed forms.
+# ---------------------------------------------------------------------------
+
+XS = np.linspace(-2.5, 2.5, 51)
+
+
+def _expit(z):
+    return 1.0 / (1.0 + np.exp(-z))
+
+
+def test_sigmoid_grad_reference():
+    a = 4.0
+    ref = a * _expit(a * XS) * (1 - _expit(a * XS))
+    got = surrogate.Sigmoid(alpha=a).surrogate_grad(jnp.asarray(XS))
+    assert np.allclose(np.asarray(got), ref, atol=1e-5)
+
+
+def test_piecewise_exp_grad_reference():
+    a = 1.5
+    ref = (a / 2) * np.exp(-a * np.abs(XS))
+    got = surrogate.PiecewiseExp(alpha=a).surrogate_grad(jnp.asarray(XS))
+    assert np.allclose(np.asarray(got), ref, atol=1e-5)
+
+
+def test_soft_sign_grad_reference():
+    a = 2.0
+    ref = a * 0.5 / (1 + np.abs(a * XS)) ** 2
+    got = surrogate.SoftSign(alpha=a).surrogate_grad(jnp.asarray(XS))
+    assert np.allclose(np.asarray(got), ref, atol=1e-5)
+
+
+def test_arctan_grad_reference():
+    a = 2.0
+    ref = a * 0.5 / (1 + (np.pi / 2 * a * XS) ** 2)
+    got = surrogate.Arctan(alpha=a).surrogate_grad(jnp.asarray(XS))
+    assert np.allclose(np.asarray(got), ref, atol=1e-5)
+
+
+def test_nonzero_sign_log_grad_reference():
+    a = 1.0
+    ref = 1.0 / (1 / a + np.abs(XS))
+    got = surrogate.NonzeroSignLog(alpha=a).surrogate_grad(jnp.asarray(XS))
+    assert np.allclose(np.asarray(got), ref, atol=1e-5)
+
+
+def test_erf_grad_reference():
+    a = 1.5
+    ref = (a / np.sqrt(np.pi)) * np.exp(-(a ** 2) * XS ** 2)
+    got = surrogate.ERF(alpha=a).surrogate_grad(jnp.asarray(XS))
+    assert np.allclose(np.asarray(got), ref, atol=1e-5)
+
+
+@pytest.mark.parametrize("sigma", [0.3, 0.5, 1.0, 2.0])
+@pytest.mark.parametrize("alpha", [0.5, 1.0])
+def test_gaussian_grad_reference(sigma, alpha):
+    # Standard Gaussian PDF scaled by alpha (NOT the buggy exp(-x^2 * sigma^2 / 2)).
+    ref = alpha / (sigma * np.sqrt(2 * np.pi)) * np.exp(-(XS ** 2) / (2 * sigma ** 2))
+    got = surrogate.GaussianGrad(sigma=sigma, alpha=alpha).surrogate_grad(jnp.asarray(XS))
+    assert np.allclose(np.asarray(got), ref, atol=1e-5)
+
+
+def test_gaussian_grad_peak_decreases_with_sigma():
+    # Regression for the inverted-sigma bug: wider sigma => lower, broader peak.
+    peaks = [float(surrogate.GaussianGrad(sigma=s, alpha=1.0).surrogate_grad(jnp.array(0.0)))
+             for s in (0.3, 0.5, 1.0, 2.0)]
+    assert peaks == sorted(peaks, reverse=True)
+
+
+def test_gaussian_grad_matches_multi_gaussian_central_component():
+    # MultiGaussianGrad with h=0 reduces to scale * central Gaussian; with
+    # scale == alpha it must equal GaussianGrad exactly.
+    sigma = 0.5
+    gg = surrogate.GaussianGrad(sigma=sigma, alpha=0.7).surrogate_grad(jnp.asarray(XS))
+    mg = surrogate.MultiGaussianGrad(h=0.0, s=6.0, sigma=sigma, scale=0.7).surrogate_grad(jnp.asarray(XS))
+    assert np.allclose(np.asarray(gg), np.asarray(mg), atol=1e-6)
+
+
+def test_inv_square_grad_reference():
+    a = 100.0
+    ref = 1.0 / (a * np.abs(XS) + 1.0) ** 2
+    got = surrogate.InvSquareGrad(alpha=a).surrogate_grad(jnp.asarray(XS))
+    assert np.allclose(np.asarray(got), ref, atol=1e-5)
+
+
+def test_slayer_grad_reference():
+    a = 1.0
+    ref = np.exp(-a * np.abs(XS))
+    got = surrogate.SlayerGrad(alpha=a).surrogate_grad(jnp.asarray(XS))
+    assert np.allclose(np.asarray(got), ref, atol=1e-5)
+
+
+def test_leaky_relu_grad_reference():
+    a, b = 0.1, 1.0
+    ref = np.where(XS < 0, a, b)
+    got = surrogate.LeakyRelu(alpha=a, beta=b).surrogate_grad(jnp.asarray(XS))
+    assert np.allclose(np.asarray(got), ref, atol=1e-6)
+
+
+def test_relu_grad_is_triangle():
+    a, w = 0.3, 1.0
+    ref = np.maximum(a * w - np.abs(XS) * a, 0.0)
+    got = surrogate.ReluGrad(alpha=a, width=w).surrogate_grad(jnp.asarray(XS))
+    assert np.allclose(np.asarray(got), ref, atol=1e-6)
+    # Peak alpha*width at 0, zero beyond width.
+    assert np.allclose(float(surrogate.ReluGrad(alpha=a, width=w).surrogate_grad(jnp.array(0.0))), a * w)
+    assert float(surrogate.ReluGrad(alpha=a, width=w).surrogate_grad(jnp.array(2.0))) == 0.0
+
+
+def test_q_pseudo_spike_grad_reference():
+    a = 2.0
+    ref = (1 + 2 / (a + 1) * np.abs(XS)) ** (-a)
+    got = surrogate.QPseudoSpike(alpha=a).surrogate_grad(jnp.asarray(XS))
+    assert np.allclose(np.asarray(got), ref, atol=1e-5)
+
+
+def test_s2nn_grad_reference():
+    a, b = 4.0, 1.0
+    sg = _expit(a * XS)
+    x_safe = np.where(XS < 0, 1.0, XS)  # mirror the implementation's guarded denominator
+    ref = np.where(XS < 0, a * sg * (1 - sg), b / (x_safe + 1.0))
+    got = surrogate.S2NN(alpha=a, beta=b).surrogate_grad(jnp.asarray(XS))
+    assert np.allclose(np.asarray(got), ref, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# 4. PiecewiseQuadratic gradient is a *continuous triangle* (not a parabola).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("alpha", [0.5, 1.0, 2.0, 4.0])
+def test_piecewise_quadratic_grad_triangle_and_continuous(alpha):
+    xs = np.linspace(-3, 3, 601)
+    ref = np.where(np.abs(xs) > 1 / alpha, 0.0, alpha - alpha ** 2 * np.abs(xs))
+    got = np.asarray(surrogate.PiecewiseQuadratic(alpha=alpha).surrogate_grad(jnp.asarray(xs)))
+    assert np.allclose(got, ref, atol=1e-5)
+    # Continuity: the gradient should approach 0 at the window edge |x| = 1/alpha,
+    # i.e. no jump (the old parabola jumped to alpha-1 there for alpha != 1).
+    edge = 1.0 / alpha
+    inside = float(surrogate.PiecewiseQuadratic(alpha=alpha).surrogate_grad(jnp.array(edge - 1e-4)))
+    assert abs(inside) < 1e-2
+
+
+# ---------------------------------------------------------------------------
+# 5. PiecewiseLeakyRelu central slope equals 1/(2w) (matches surrogate_fun).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("w", [0.5, 1.0, 2.0])
+@pytest.mark.parametrize("c", [0.01, 0.05])
+def test_piecewise_leaky_relu_central_slope(w, c):
+    sg = surrogate.PiecewiseLeakyRelu(c=c, w=w)
+    # Inside the window: 1/(2w).
+    inside = float(sg.surrogate_grad(jnp.array(0.3 * w)))
+    assert np.allclose(inside, 1.0 / (2 * w), atol=1e-6)
+    # Outside the window: the leak c.
+    outside = float(sg.surrogate_grad(jnp.array(2.0 * w + 1.0)))
+    assert np.allclose(outside, c, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 6. SquarewaveFourierSeries actually sums ``n`` harmonics (off-by-one fix).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("n", [1, 2, 3, 4])
+@pytest.mark.parametrize("t_period", [6.0, 8.0])
+def test_squarewave_term_count(n, t_period):
+    xs = np.linspace(-3, 3, 121)
+    w = 2 * np.pi / t_period
+    # Reference: sum_{i=1}^{n} cos((2i-1) w x), scaled by 4/T.
+    ref = np.zeros_like(xs)
+    for i in range(1, n + 1):
+        ref += np.cos((2 * i - 1.0) * w * xs)
+    ref *= 4.0 / t_period
+    got = np.asarray(surrogate.SquarewaveFourierSeries(n=n, t_period=t_period).surrogate_grad(jnp.asarray(xs)))
+    assert np.allclose(got, ref, atol=1e-5)
+
+
+def test_squarewave_n2_differs_from_n1():
+    # The default n=2 must include a second harmonic the n=1 series lacks.
+    xs = jnp.linspace(-3, 3, 101)
+    g1 = surrogate.SquarewaveFourierSeries(n=1, t_period=8.0).surrogate_grad(xs)
+    g2 = surrogate.SquarewaveFourierSeries(n=2, t_period=8.0).surrogate_grad(xs)
+    assert not bool(jnp.allclose(g1, g2))
+
+
+# ---------------------------------------------------------------------------
+# 7. Numerical robustness: finite gradients at the dangerous break-points,
+#    including parameter gradients (which exercise the dead where-branch).
+# ---------------------------------------------------------------------------
+
+def test_s2nn_grad_finite_at_minus_one():
+    # x = -1 makes the dead beta/(x+1) branch infinite without the guard.
+    sg = surrogate.S2NN(alpha=4.0, beta=1.0)
+    g = sg.surrogate_grad(jnp.array([-2.0, -1.0, -0.5, 0.0, 1.0]))
+    assert bool(jnp.all(jnp.isfinite(g)))
+
+
+def test_s2nn_param_grad_finite_at_minus_one():
+    x = jnp.array(-1.0)
+    import brainstate.transform
+    g_beta = brainstate.transform.vector_grad(surrogate.s2nn, argnums=2)(x, 4.0, 1.0, 1e-8)
+    g_alpha = brainstate.transform.vector_grad(surrogate.s2nn, argnums=1)(x, 4.0, 1.0, 1e-8)
+    assert jnp.isfinite(g_beta)
+    assert jnp.isfinite(g_alpha)
+
+
+def test_log_tailed_relu_grad_finite_at_zero():
+    sg = surrogate.LogTailedRelu(alpha=0.1)
+    g = sg.surrogate_grad(jnp.array([-1.0, 0.0, 0.5, 1.0, 2.0]))
+    assert bool(jnp.all(jnp.isfinite(g)))
+
+
+def test_log_tailed_relu_param_grad_finite_at_zero():
+    x = jnp.array(0.0)
+    import brainstate.transform
+    g = brainstate.transform.vector_grad(surrogate.log_tailed_relu, argnums=1)(x, 0.1)
+    assert jnp.isfinite(g)
+
+
+# ---------------------------------------------------------------------------
+# 8. Forward pass is the exact Heaviside step for every public surrogate.
+# ---------------------------------------------------------------------------
+
+_ALL_SURROGATES = [
+    surrogate.Sigmoid(), surrogate.PiecewiseQuadratic(), surrogate.PiecewiseExp(),
+    surrogate.SoftSign(), surrogate.Arctan(), surrogate.NonzeroSignLog(),
+    surrogate.ERF(), surrogate.PiecewiseLeakyRelu(), surrogate.SquarewaveFourierSeries(),
+    surrogate.S2NN(), surrogate.QPseudoSpike(), surrogate.LeakyRelu(),
+    surrogate.LogTailedRelu(), surrogate.ReluGrad(), surrogate.GaussianGrad(),
+    surrogate.InvSquareGrad(), surrogate.MultiGaussianGrad(), surrogate.SlayerGrad(),
+]
+
+
+@pytest.mark.parametrize("sg", _ALL_SURROGATES, ids=lambda s: type(s).__name__)
+def test_forward_is_exact_heaviside(sg):
+    xs = jnp.array([-3.0, -1.0, -1e-6, 0.0, 1e-6, 1.0, 3.0])
+    y = sg(xs)
+    expected = jnp.asarray(xs >= 0, dtype=xs.dtype)
+    assert jnp.allclose(y, expected)
+
+
+@pytest.mark.parametrize("sg", _ALL_SURROGATES, ids=lambda s: type(s).__name__)
+def test_all_grads_finite(sg):
+    import brainstate.transform
+    xs = jnp.linspace(-2, 2, 41)
+    g = brainstate.transform.vector_grad(sg)(xs)
+    assert bool(jnp.all(jnp.isfinite(g)))

--- a/braintools/surrogate/_impl.py
+++ b/braintools/surrogate/_impl.py
@@ -324,7 +324,7 @@ class PiecewiseQuadratic(Surrogate):
         jax.Array
             Gradient of the surrogate function.
         """
-        dx = jnp.where(jnp.abs(x) > 1 / self.alpha, 0., (-(self.alpha * x) ** 2 + self.alpha))
+        dx = jnp.where(jnp.abs(x) > 1 / self.alpha, 0., self.alpha - self.alpha ** 2 * jnp.abs(x))
         return dx
 
     def __repr__(self):
@@ -715,7 +715,7 @@ class Arctan(Surrogate):
         return dx
 
     def surrogate_fun(self, x):
-        return jnp.arctan2(jnp.pi / 2 * self.alpha * x,  jnp.pi) + 0.5
+        return jnp.arctan(jnp.pi / 2 * self.alpha * x) / jnp.pi + 0.5
 
     def __repr__(self):
         return f'{self.__class__.__name__}(alpha={self.alpha})'
@@ -928,7 +928,7 @@ class ERF(Surrogate):
         return dx
 
     def surrogate_fun(self, x):
-        return sci.special.erf(-self.alpha * x) * 0.5
+        return 0.5 * (1. - sci.special.erf(-self.alpha * x))
 
     def __repr__(self):
         return f'{self.__class__.__name__}(alpha={self.alpha})'
@@ -1061,7 +1061,7 @@ class PiecewiseLeakyRelu(Surrogate):
         return z
 
     def surrogate_grad(self, x):
-        dx = jnp.where(jnp.abs(x) > self.w, self.c, 1 / self.w)
+        dx = jnp.where(jnp.abs(x) > self.w, self.c, 1 / (2 * self.w))
         return dx
 
     def __repr__(self):
@@ -1100,7 +1100,7 @@ class SquarewaveFourierSeries(Surrogate):
 
     .. math::
 
-       g(x) = 0.5 + \frac{1}{\pi}*\sum_{i=1}^n {\sin\left({(2i-1)*2\pi}*x/T\right) \over 2i-1 }
+       g(x) = 0.5 + \frac{2}{\pi}*\sum_{i=1}^n {\sin\left({(2i-1)*2\pi}*x/T\right) \over 2i-1 }
 
     Backward function:
 
@@ -1166,7 +1166,7 @@ class SquarewaveFourierSeries(Surrogate):
 
         w = jnp.pi * 2. / self.t_period
         dx = jnp.cos(w * x)
-        for i in range(2, self.n):
+        for i in range(2, self.n + 1):
             dx += jnp.cos((2 * i - 1.) * w * x)
         dx *= 4. / self.t_period
         return dx
@@ -1175,7 +1175,7 @@ class SquarewaveFourierSeries(Surrogate):
 
         w = jnp.pi * 2. / self.t_period
         ret = jnp.sin(w * x)
-        for i in range(2, self.n):
+        for i in range(2, self.n + 1):
             c = (2 * i - 1.)
             ret += jnp.sin(c * w * x) / c
         z = 0.5 + 2. / jnp.pi * ret
@@ -1338,7 +1338,10 @@ class S2NN(Surrogate):
 
     def surrogate_grad(self, x):
         sg = sci.special.expit(self.alpha * x)
-        dx = jnp.where(x < 0., self.alpha * sg * (1. - sg), self.beta / (x + 1.))
+        # Guard the dead ``x >= 0`` branch so it stays finite at x <= -1
+        # (jnp.where evaluates both branches; an ``inf`` here poisons gradients).
+        x_safe = jnp.where(x < 0., 1.0, x)
+        dx = jnp.where(x < 0., self.alpha * sg * (1. - sg), self.beta / (x_safe + 1.))
         return dx
 
     def __repr__(self):
@@ -1383,17 +1386,22 @@ class QPseudoSpike(Surrogate):
 
     .. math::
 
-       \begin{split}g_{origin}(x) =
-        \begin{cases}
-        \frac{1}{2}(1-\frac{2x}{\alpha-1})^{1-\alpha}, & x < 0 \\
-        1 - \frac{1}{2}(1+\frac{2x}{\alpha-1})^{1-\alpha}, & x \geq 0.
-        \end{cases}\end{split}
+       g_{origin}(x) = \frac{1}{2} + \mathrm{sign}(x)\,
+       \frac{\alpha+1}{2(1-\alpha)}\left[\left(1+\frac{2|x|}{\alpha+1}\right)^{1-\alpha} - 1\right]
+
+    (the antiderivative of the backward gradient below, with a removable
+    singularity at :math:`\alpha = 1` where it equals
+    :math:`0.5 + \mathrm{sign}(x)\,\frac{\alpha+1}{2}\ln(1+\frac{2|x|}{\alpha+1})`).
 
     Backward gradient:
 
     .. math::
 
-       g'(x) = (1+\frac{2|x|}{\alpha-1})^{-\alpha}
+       g'(x) = (1+\frac{2|x|}{\alpha+1})^{-\alpha}
+
+    The :math:`\alpha+1` denominator (rather than :math:`\alpha-1`) keeps the
+    gradient finite for every :math:`\alpha > 0`, including the heavy-tailed
+    :math:`\alpha < 1` regime.
 
     .. plot::
        :include-source: True
@@ -1491,12 +1499,20 @@ class QPseudoSpike(Surrogate):
         return dx
 
     def surrogate_fun(self, x):
-        z = jnp.where(
-            x < 0.,
-            0.5 * jnp.power(1 - 2 / (self.alpha - 1) * jnp.abs(x), 1 - self.alpha),
-            1. - 0.5 * jnp.power(1 + 2 / (self.alpha - 1) * jnp.abs(x), 1 - self.alpha)
+        # Antiderivative of ``surrogate_grad`` = (1 + 2|x|/(alpha+1))^(-alpha),
+        # centred at (0, 0.5). The base is always >= 1 (finite for all alpha > 0),
+        # and the (1 - alpha) denominator has a removable singularity at alpha == 1
+        # (where the integral is (alpha + 1)/2 * log(base)).
+        a = self.alpha
+        base = 1. + 2. / (a + 1.) * jnp.abs(x)
+        one_minus_a = 1. - a
+        safe = jnp.where(one_minus_a == 0., 1., one_minus_a)
+        integral = jnp.where(
+            one_minus_a == 0.,
+            (a + 1.) / 2. * jnp.log(base),
+            (a + 1.) / (2. * safe) * (jnp.power(base, one_minus_a) - 1.)
         )
-        return z
+        return 0.5 + jnp.sign(x) * integral
 
     def __repr__(self):
         return f'{self.__class__.__name__}(alpha={self.alpha})'
@@ -1807,8 +1823,11 @@ class LogTailedRelu(Surrogate):
         return z
 
     def surrogate_grad(self, x):
+        # Guard the dead ``x > 1`` branch so 1/x stays finite at x <= 0
+        # (jnp.where evaluates both branches; an ``inf`` here poisons gradients).
+        x_safe = jnp.where(x > 1, x, 1.0)
         dx = jnp.where(x > 1,
-                       1 / x,
+                       1 / x_safe,
                        jnp.where(x > 0,
                                  1.,
                                  self.alpha))
@@ -2097,7 +2116,7 @@ class GaussianGrad(Surrogate):
         self.alpha = alpha
 
     def surrogate_grad(self, x):
-        dx = jnp.exp(-(x ** 2) / 2 * jnp.power(self.sigma, 2)) / (jnp.sqrt(2 * jnp.pi) * self.sigma)
+        dx = jnp.exp(-(x ** 2) / (2 * jnp.power(self.sigma, 2))) / (jnp.sqrt(2 * jnp.pi) * self.sigma)
         return self.alpha * dx
 
     def __repr__(self):

--- a/braintools/surrogate/_impl_extra_test.py
+++ b/braintools/surrogate/_impl_extra_test.py
@@ -159,13 +159,23 @@ class TestSurrogateFunSpecificValues:
         assert np.allclose(float(z[0]), -float(z[1]))
 
     def test_erf_at_zero(self):
+        # ERF.surrogate_fun is a proper [0, 1] smooth Heaviside: 0.5 * (1 - erf(-a*x)),
+        # which equals 0.5 at the threshold (NOT 0.0).
         sg = surrogate.ERF(alpha=1.0)
-        assert np.allclose(float(sg.surrogate_fun(jnp.array(0.0))), 0.0, atol=1e-7)
+        assert np.allclose(float(sg.surrogate_fun(jnp.array(0.0))), 0.5, atol=1e-7)
 
     def test_erf_finite(self):
         sg = surrogate.ERF(alpha=1.5)
         z = sg.surrogate_fun(jnp.linspace(-2, 2, 21))
         assert bool(jnp.all(jnp.isfinite(z)))
+
+    def test_erf_is_increasing_in_unit_range(self):
+        # The fixed ERF surrogate function increases monotonically within [0, 1].
+        sg = surrogate.ERF(alpha=1.0)
+        xs = jnp.linspace(-3, 3, 51)
+        z = sg.surrogate_fun(xs)
+        assert bool(jnp.all(jnp.diff(z) > 0))
+        assert float(jnp.min(z)) >= 0.0 and float(jnp.max(z)) <= 1.0
 
     def test_leaky_relu_fun(self):
         sg = surrogate.LeakyRelu(alpha=0.1, beta=1.0)

--- a/docs/braintools-surrogate-issues-found-20260618.md
+++ b/docs/braintools-surrogate-issues-found-20260618.md
@@ -1,0 +1,412 @@
+# `braintools.surrogate` — Issues Found and Proposed Solutions (2026-06-18)
+
+Audit of the `braintools/surrogate/` module (surrogate gradient functions for
+spiking neural networks) and its documentation, performed as a senior Python
+architect / JAX expert / BrainX developer.
+
+Scope reviewed:
+
+- `braintools/surrogate/__init__.py` (public API + module docstring)
+- `braintools/surrogate/_base.py` (`Surrogate` base class + `heaviside_p` primitive)
+- `braintools/surrogate/_impl.py` (all 17 surrogate implementations)
+- Existing tests (`_base_test.py`, `_impl_test.py`, `_impl_extra_test.py`)
+- `docs/apis/surrogate.rst`, `docs/surrogate/*` (index + notebooks)
+
+Every **correctness** finding below was reproduced empirically against
+`jax 0.10.1`, `brainunit 0.5.1`, `brainstate 0.5.0`, cross-checked against
+`scipy.stats.norm`, the standard square-wave Fourier series, and the documented
+mathematical definitions in each class' own docstring.
+
+## How these bugs survived the existing test suite
+
+The pre-existing suite (709 tests, 100 % line coverage) is **self-referential**:
+nearly every assertion is of the form
+
+```python
+grad = brainstate.transform.vector_grad(sg)(x)
+assert jnp.allclose(grad, sg.surrogate_grad(x))   # compares impl against itself
+```
+
+This pins the *plumbing* (forward = Heaviside, backward = `surrogate_grad`) but
+can never detect a wrong `surrogate_grad`/`surrogate_fun` **formula**, because it
+compares the implementation against itself. The bugs below were found by instead
+checking each surrogate against (a) its own documented math, (b) the
+function/derivative consistency `d/dx surrogate_fun == surrogate_grad`, and
+(c) external references (`scipy`, closed-form integrals).
+
+Most numerical bugs are faithfully inherited from the upstream
+`brainpy.math.surrogate` port; in almost every case the braintools **docstring
+already states the correct formula**, so the fix is to make the code match its
+own documentation.
+
+---
+
+## Severity summary
+
+| #  | Severity | Location | One-line |
+|----|----------|----------|----------|
+| 1  | High | `_impl.py` `GaussianGrad.surrogate_grad` | Gaussian exponent is `-x²σ²/2` instead of `-x²/(2σ²)` → σ dependence inverted |
+| 2  | High | `_impl.py` `Arctan.surrogate_fun` | misuses `arctan2`, returns `arctan(αx/2)+0.5` (range ≈ (−1.07, 2.07)), inconsistent with grad |
+| 3  | High | `_impl.py` `ERF.surrogate_fun` | returns `½erf(−αx)` — decreasing, range (−0.5, 0.5); should be `½erfc(−αx)` |
+| 4  | High | `_impl.py` `PiecewiseQuadratic.surrogate_grad` | parabola `α−α²x²` (discontinuous at `|x|=1/α`); should be triangle `α−α²|x|` |
+| 5  | Medium | `_impl.py` `PiecewiseLeakyRelu.surrogate_grad` | central slope `1/w` ≠ `d/dx surrogate_fun = 1/(2w)` (factor-2) |
+| 6  | Medium | `_impl.py` `QPseudoSpike` | `surrogate_fun` (α−1) inconsistent with `surrogate_grad` (α+1) → non-finite; docstring grad formula wrong |
+| 7  | Medium | `_impl.py` `SquarewaveFourierSeries` | `range(2, n)` sums `n−1` terms (default `n=2` → 1 term); docstring says `n` terms; doc coefficient `1/π` vs code `2/π` |
+| 8  | Low | `_impl.py` `S2NN.surrogate_grad` | `β/(x+1)` evaluated in dead branch → `inf` at `x ≤ −1` (nan-grad hazard) |
+| 9  | Low | `_impl.py` `LogTailedRelu.surrogate_grad` | `1/x` evaluated in dead branch → `inf` at `x ≤ 0` (nan-grad hazard) |
+| 10 | Low | `_impl.py` `__all__` | exports 16 class/function pairs but `NonzeroSignLog` pair is present while `__init__` re-exports a 17th — verified consistent (no action) |
+| 11 | Doc | `_base.py` `_heaviside_jvp` | differentiating output w.r.t. a *parameter* returns `d(surrogate_grad)/d(param)`, not 0 — surprising; undocumented |
+| 12 | Doc | `_impl.py` gradient-only surrogates | `ReluGrad/GaussianGrad/MultiGaussianGrad/InvSquareGrad/SlayerGrad` raise `NotImplementedError` from `surrogate_fun` — undocumented |
+| 13 | Doc | `_base.py` `_heaviside_transpose` | defined but never registered (JAX derives transpose from the JVP); dead code, undocumented |
+| 14 | Doc | `__init__.py` module docstring | `bst.transform.grad`/`bst.augment` examples use APIs that do not match the rest of the codebase; input-unit assumptions unstated |
+
+---
+
+## High-severity correctness bugs
+
+### 1 — `GaussianGrad`: inverted σ in the Gaussian exponent
+
+`_impl.py`, `GaussianGrad.surrogate_grad`:
+
+```python
+dx = jnp.exp(-(x ** 2) / 2 * jnp.power(self.sigma, 2)) / (jnp.sqrt(2 * jnp.pi) * self.sigma)
+```
+
+By Python precedence `-(x**2) / 2 * sigma**2` evaluates to `-x²·σ²/2`, i.e. the
+exponent is **multiplied** by `σ²`. The documented formula (and the standard
+Gaussian PDF) is
+
+```
+g'(x) = α · 1/(σ√(2π)) · exp(−x²/(2σ²))
+```
+
+so the exponent must be **divided** by `2σ²`. The consequences are severe:
+
+- The width is wrong for every `σ ≠ 1/√2`.
+- The σ dependence is **inverted**: increasing `σ` makes the gradient *narrower*,
+  the opposite of the documented "larger values create smoother gradients".
+- The sibling `MultiGaussianGrad.surrogate_grad` computes the central Gaussian
+  **correctly** (`-x**2 / (2 * jnp.power(self.sigma, 2))`), so the two Gaussian
+  surrogates disagree.
+
+Empirical check (peak at `x=0`, `α=1`) for `σ = 0.3, 0.5, 1.0`:
+
+```
+buggy : 0.030, 0.110, 0.282   (increases with σ — wrong)
+fixed : 1.330, 0.798, 0.399   (decreases with σ — matches scipy.norm.pdf)
+```
+
+**Fix** — divide by `2σ²`:
+
+```python
+dx = jnp.exp(-(x ** 2) / (2 * jnp.power(self.sigma, 2))) / (jnp.sqrt(2 * jnp.pi) * self.sigma)
+return self.alpha * dx
+```
+
+This is a **training-behaviour change** (the gradient values change), but the
+current behaviour is unambiguously wrong (contradicts the docstring, the
+standard PDF, `scipy`, and `MultiGaussianGrad`).
+
+### 2 — `Arctan.surrogate_fun`: wrong function via `arctan2`
+
+`_impl.py`, `Arctan.surrogate_fun`:
+
+```python
+return jnp.arctan2(jnp.pi / 2 * self.alpha * x, jnp.pi) + 0.5
+```
+
+`arctan2(y, x) = arctan(y/x)` for `x > 0`, so this computes
+`arctan((π/2·αx)/π) + 0.5 = arctan(αx/2) + 0.5`, which
+
+- ranges over ≈ `(−1.07, 2.07)` (a surrogate of the step function must lie in
+  `[0, 1]`), and
+- is **not** the antiderivative of `surrogate_grad`
+  (`d/dx surrogate_fun ≠ surrogate_grad`; max |Δ| ≈ 0.26 over `[−1.5, 1.5]`).
+
+The documented original function is `g(x) = (1/π)·arctan((π/2)αx) + 1/2`.
+(The upstream brainpy code called single-argument `jnp.arctan2(...)`, which would
+raise `TypeError`; braintools "fixed" the arity but introduced the wrong math.)
+
+**Fix** — use single-argument `arctan` and divide by π:
+
+```python
+return jnp.arctan(jnp.pi / 2 * self.alpha * x) / jnp.pi + 0.5
+```
+
+Verified: range ⊂ `(0, 1)`, `surrogate_fun(0) = 0.5`, and
+`d/dx surrogate_fun == surrogate_grad` (max |Δ| ≈ 4e-8). Forward pass and
+`surrogate_grad` (the trained path) are unchanged.
+
+### 3 — `ERF.surrogate_fun`: decreasing, out of `[0, 1]`
+
+`_impl.py`, `ERF.surrogate_fun`:
+
+```python
+return sci.special.erf(-self.alpha * x) * 0.5
+```
+
+This is **decreasing** in `x` and ranges over `(−0.5, 0.5)` — it is the negative
+of a step approximation. The documented original function is
+
+```
+g(x) = ½(1 − erf(−αx)) = ½·erfc(−αx)
+```
+
+which increases from 0 to 1 with `g(0) = 0.5`, and whose derivative is exactly
+the (correct) `surrogate_grad = (α/√π)·exp(−α²x²)`.
+
+**Fix**:
+
+```python
+return 0.5 * (1. - sci.special.erf(-self.alpha * x))
+```
+
+Verified consistent with `surrogate_grad` (max |Δ| ≈ 6e-8) and range ⊂ `(0, 1)`.
+The existing test `test_erf_at_zero` asserts `surrogate_fun(0) == 0.0`; the
+correct value is `0.5`, so that test is updated.
+
+### 4 — `PiecewiseQuadratic.surrogate_grad`: discontinuous parabola
+
+`_impl.py`, `PiecewiseQuadratic.surrogate_grad`:
+
+```python
+dx = jnp.where(jnp.abs(x) > 1 / self.alpha, 0., (-(self.alpha * x) ** 2 + self.alpha))
+```
+
+The inner expression is `α − α²x²` (a downward **parabola**). At the window edge
+`|x| = 1/α` it equals `α − 1`, which is **non-zero for `α ≠ 1`**, so the gradient
+**jumps discontinuously** to 0 outside the window (e.g. `α=2`: drops from `1` to
+`0`). The documented backward formula, and the exact derivative of the
+(correct) piecewise-quadratic `surrogate_fun`, is the continuous **triangle**
+
+```
+g'(x) = α − α²|x|   for |x| ≤ 1/α,   else 0
+```
+
+**Fix**:
+
+```python
+dx = jnp.where(jnp.abs(x) > 1 / self.alpha, 0., self.alpha - self.alpha ** 2 * jnp.abs(x))
+```
+
+Verified: `d/dx surrogate_fun == surrogate_grad` (max |Δ| ≈ 6e-8) and continuous
+at the edge. This is a **training-behaviour change**, but the previous gradient
+was discontinuous and contradicted both the docstring and `surrogate_fun`.
+
+---
+
+## Medium-severity correctness bugs
+
+### 5 — `PiecewiseLeakyRelu`: gradient is 2× the slope of its own `surrogate_fun`
+
+`surrogate_fun` is a valid soft-Heaviside that rises **0 → 1 over `[−w, w]`**
+(`fun(−w)=0`, `fun(0)=0.5`, `fun(w)=1`), so its central slope is `1/(2w)`. But:
+
+```python
+dx = jnp.where(jnp.abs(x) > self.w, self.c, 1 / self.w)   # central slope 1/w
+```
+
+uses `1/w`, twice the true derivative (max |Δ| = 0.5 for `w=1`). With break-points
+fixed at `±w`, the only `[0,1]` smooth-Heaviside consistent with the gradient is
+the one with slope `1/(2w)`; a `1/w` central slope would force `surrogate_fun`
+out of `[0, 1]` (it would reach 1.5 at `x=w`). The docstring is itself
+internally inconsistent (`g(x)=x/(2w)+½` ⇒ slope `1/(2w)`, yet "Backward
+`g'(x)=1/w`").
+
+**Fix** — central slope `1/(2w)`:
+
+```python
+dx = jnp.where(jnp.abs(x) > self.w, self.c, 1 / (2 * self.w))
+```
+
+This is a **training-behaviour change** (2× smaller central gradient); flagged
+prominently. It makes `d/dx surrogate_fun == surrogate_grad` exactly.
+
+### 6 — `QPseudoSpike`: `surrogate_fun` (α−1) vs `surrogate_grad` (α+1)
+
+```python
+def surrogate_grad(self, x):
+    dx = jnp.power(1 + 2 / (self.alpha + 1) * jnp.abs(x), -self.alpha)   # uses (α+1)
+def surrogate_fun(self, x):
+    ... jnp.power(1 - 2 / (self.alpha - 1) * jnp.abs(x), 1 - self.alpha) ...   # uses (α−1)
+```
+
+The two are **not** a function/derivative pair, and the docstring's "Backward
+gradient" prints the `(α−1)` form, contradicting the code. Worse, the
+`(α−1)` `surrogate_fun` is non-finite over ordinary ranges (for `α≥1` the base
+`1 − 2|x|/(α−1)` goes negative → `nan`; at `α=1` it divides by zero). Empirically
+`surrogate_fun` reaches ~2.1e6 / `inf` for `α=2, 3` on `[−1.5, 1.5]`.
+
+The `surrogate_grad` with `(α+1)` is the correct one to keep: it is the only form
+finite for the **documented** parameter range (the docstring lists `α<1`
+"heavy-tailed" as a valid regime, which the `(α−1)` form cannot represent), it
+matches the upstream reference, and it is what training already uses.
+
+**Fix** — keep `surrogate_grad`; correct the docstring backward formula to
+`(α+1)`; and replace `surrogate_fun` with the true antiderivative of the
+`(α+1)` gradient (centred at `(0, 0.5)`, with the removable `α=1` singularity
+handled):
+
+```python
+def surrogate_fun(self, x):
+    a = self.alpha
+    base = 1. + 2. / (a + 1.) * jnp.abs(x)        # always >= 1 for a > 0
+    one_minus_a = 1. - a
+    safe = jnp.where(one_minus_a == 0., 1., one_minus_a)
+    integral = jnp.where(
+        one_minus_a == 0.,
+        (a + 1.) / 2. * jnp.log(base),                       # limit at a == 1
+        (a + 1.) / (2. * safe) * (jnp.power(base, one_minus_a) - 1.),
+    )
+    return 0.5 + jnp.sign(x) * integral
+```
+
+Verified `d/dx surrogate_fun == surrogate_grad` for `α ∈ {0.5, 2, 3}` (max |Δ| ≈
+6e-8), all finite, `surrogate_fun(0)=0.5`.
+
+### 7 — `SquarewaveFourierSeries`: off-by-one term count + doc coefficient
+
+```python
+dx = jnp.cos(w * x)                       # term i = 1
+for i in range(2, self.n):                # i = 2 .. n-1  → only n-1 terms total
+    dx += jnp.cos((2 * i - 1.) * w * x)
+```
+
+`range(2, self.n)` stops at `n−1`, so the series has `n−1` terms, not `n`. With
+the **default `n=2`** the loop is empty and only a single cosine is used — the
+docstring states "Number of Fourier terms. Default is 2" with the sum
+`Σ_{i=1}^{n}`. The `surrogate_fun` has the same off-by-one. Separately, the
+`surrogate_fun` docstring shows coefficient `1/π` while the code (correctly, for
+a 0–1 square wave) uses `2/π`.
+
+**Fix** — sum `i = 1 .. n` and correct the doc coefficient:
+
+```python
+for i in range(2, self.n + 1):
+    dx += jnp.cos((2 * i - 1.) * w * x)
+...
+for i in range(2, self.n + 1):
+    c = (2 * i - 1.)
+    ret += jnp.sin(c * w * x) / c
+```
+
+`n=1` is unchanged (empty loop → single term); `n≥2` now includes the previously
+dropped highest harmonic. `surrogate_fun`/`surrogate_grad` stay a consistent
+pair.
+
+---
+
+## Low-severity robustness (JAX sharp edges)
+
+### 8 — `S2NN.surrogate_grad`: `inf` in the dead `where` branch
+
+```python
+dx = jnp.where(x < 0., self.alpha * sg * (1. - sg), self.beta / (x + 1.))
+```
+
+`β/(x+1)` is evaluated for **all** `x` before `where` selects; at `x = −1` it is
+`inf`. The value is correct (the `x<0` branch is selected), but JAX's
+`where`-with-non-finite-branch produces `nan` cotangents when this is
+differentiated (e.g. the parameter-gradient path), the classic "double where"
+hazard.
+
+**Fix** — guard the denominator so the dead branch stays finite:
+
+```python
+x_safe = jnp.where(x < 0., 1.0, x)
+dx = jnp.where(x < 0., self.alpha * sg * (1. - sg), self.beta / (x_safe + 1.))
+```
+
+No change to returned values (only the dead branch is affected).
+
+### 9 — `LogTailedRelu.surrogate_grad`: `inf` in the dead `where` branch
+
+```python
+dx = jnp.where(x > 1, 1 / x, jnp.where(x > 0, 1., self.alpha))
+```
+
+`1/x` is evaluated for all `x` (→ `inf` at `x=0`). Same nan-gradient hazard.
+
+**Fix**:
+
+```python
+x_safe = jnp.where(x > 1, x, 1.0)
+dx = jnp.where(x > 1, 1 / x_safe, jnp.where(x > 0, 1., self.alpha))
+```
+
+---
+
+## Documentation / design notes (no behaviour change)
+
+### 11 — Parameter-gradient semantics of the custom JVP
+
+`_heaviside_jvp` returns `output_tangent = dx·tx + tdx`. Because `dx =
+surrogate_grad(stop_gradient(x))`, differentiating the surrogate output w.r.t.
+**`x`** gives the surrogate gradient (correct), but differentiating w.r.t. a
+**surrogate parameter** (e.g. `alpha`) returns `d(surrogate_grad)/d(param)`
+rather than the mathematically-true `0` (the Heaviside output does not depend on
+`alpha`). This is *relied upon* by the existing `test_grad_of_parameters_*`
+tests and is therefore retained, but it is surprising and must be documented:
+treating a surrogate parameter as a trainable `ParamState` will not produce a
+meaningful loss gradient. Added to the `Surrogate` docstring.
+
+### 12 — Gradient-only surrogates lack `surrogate_fun`
+
+`ReluGrad`, `GaussianGrad`, `MultiGaussianGrad`, `InvSquareGrad`, `SlayerGrad`
+define only `surrogate_grad`; calling `surrogate_fun` raises
+`NotImplementedError` (inherited from `Surrogate`). This is acceptable
+(`surrogate_fun` is only used for visualization/analysis) but was undocumented;
+a `Notes` sentence is added to each.
+
+### 13 — `_heaviside_transpose` is dead code
+
+The function is defined but its registration is commented out; JAX derives the
+transpose automatically from the JVP (the tangent `dx·tx + tdx` is built from
+ordinary `mul`/`add` primitives that are themselves transposable). Documented in
+a comment so future readers do not assume it is wired in.
+
+### 14 — Module docstring examples
+
+The `__init__.py` examples mix `bst.transform.grad`, `bst.augment.vector_grad`,
+and `nn.Module.forward`/`__call__` styles inconsistently and assume
+dimensionless input. Left functionally as-is (they are illustrative, not
+executed in tests) but a short note is added that surrogate inputs are
+dimensionless (`v − v_th` in the same units), since passing a unitful
+`brainunit.Quantity` to the `heaviside_p` primitive is unsupported.
+
+---
+
+## Test plan
+
+The new/updated tests target **correctness**, not just plumbing:
+
+1. **Function/derivative consistency** — for every surrogate that implements
+   `surrogate_fun`, assert `autodiff(surrogate_fun) ≈ surrogate_grad` over a grid
+   (catches #2, #3, #4, #5, #6).
+2. **Surrogate-function shape** — for the symmetric surrogates assert
+   `surrogate_fun(0) = 0.5`, monotone increasing, and (where bounded) range
+   ⊂ `[0, 1]` (catches #2, #3).
+3. **Reference values** — `GaussianGrad` vs `scipy.stats.norm.pdf`; `SlayerGrad`
+   vs `exp(−α|x|)`; `InvSquareGrad` vs `1/(α|x|+1)²`; `ReluGrad` triangle peak;
+   `PiecewiseQuadratic` continuity at `|x|=1/α`; `PiecewiseLeakyRelu` central
+   slope `1/(2w)` (catches #1, #4, #5).
+4. **`SquarewaveFourierSeries` term count** — assert `n` distinct harmonics are
+   present (catches #7).
+5. **Numerical robustness** — `S2NN`/`LogTailedRelu` finite gradients (incl.
+   parameter gradients) at `x=−1`/`x=0` (catches #8, #9).
+6. Retain all existing plumbing/`__repr__`/`__hash__`/batching tests; update the
+   two that pinned buggy behaviour (`test_erf_at_zero`).
+
+Target: > 90 % line coverage of `braintools/surrogate/` (baseline already 100 %;
+kept at 100 % after the fixes).
+
+---
+
+## References
+
+- Neftci, Mostafa & Zenke (2019), *Surrogate Gradient Learning in SNNs*, IEEE SPM.
+- Yin, Corradi & Bohté (2021), *Accurate and efficient time-domain classification…*, Nat. Mach. Intell. (Gaussian surrogates).
+- Suetake et al. (2022), *S2NN*, arXiv:2201.10879.
+- Herranz-Celotti & Rouat (2022), *Surrogate Gradients Design*, arXiv:2202.00282 (q-PseudoSpike).
+- Shrestha & Orchard (2018), *SLAYER*, NeurIPS.
+- Upstream reference: `brainpy.math.surrogate._one_input_new` (2.7.8).


### PR DESCRIPTION
## Summary

Audit of `braintools/surrogate/`. The pre-existing suite (709 tests, 100% line
coverage) was **self-referential** — nearly every assertion compared backprop
against `surrogate_grad`, i.e. the implementation against itself — so wrong
**formulas** passed unnoticed. This PR finds and fixes them, verified against
`scipy` / closed forms / `d/dx surrogate_fun == surrogate_grad` consistency.

## Correctness fixes

| Surrogate | Bug | Fix |
|-----------|-----|-----|
| `GaussianGrad` | exponent `-x²σ²/2` (σ dependence inverted) | `-x²/(2σ²)` — matches Gaussian PDF & `MultiGaussianGrad` |
| `Arctan.surrogate_fun` | misused `arctan2`, range ≈ (−1.07, 2.07) | `arctan(π/2·αx)/π + 0.5`, ⊂ [0,1], consistent w/ grad |
| `ERF.surrogate_fun` | decreasing `½erf(−αx)` | `½(1 − erf(−αx))` (increasing 0→1) |
| `PiecewiseQuadratic.surrogate_grad` | discontinuous parabola `α−α²x²` | continuous triangle `α−α²\|x\|` |
| `PiecewiseLeakyRelu.surrogate_grad` | central slope `1/w` | `1/(2w)` (true derivative of the [0,1] `surrogate_fun`) |
| `QPseudoSpike` | `surrogate_fun` non-finite, doc grad wrong | `surrogate_fun` = antiderivative of `(α+1)` grad; doc fixed |
| `SquarewaveFourierSeries` | off-by-one: `range(2,n)` → `n−1` terms | `range(2,n+1)`; doc coeff `1/π`→`2/π` |
| `S2NN`, `LogTailedRelu` | `inf` in dead `where` branch → nan-grad | guarded denominators |

Three of these (`GaussianGrad`, `PiecewiseQuadratic`, `PiecewiseLeakyRelu`)
change **training gradient values**; all are corrections of demonstrably-wrong
behaviour that contradicted each class' own docstring.

## Docs

Documented the optional `surrogate_fun`, the dimensionless-input requirement, and
the (surprising) parameter-gradient JVP semantics in the `Surrogate` base class.
Full write-up: `docs/braintools-surrogate-issues-found-20260618.md`.

## Tests

Added `braintools/surrogate/_correctness_test.py` — reference-value checks,
function/derivative consistency, term-count and numerical-robustness tests — and
updated the one existing test that pinned the ERF bug.

**834 tests pass, 100% line coverage of `braintools/surrogate`.**