### PR TITLE
fix(metric): bound lfp_phase_coherence PLV to [0, 1]

### DIFF
--- a/braintools/metric/_lfp.py
+++ b/braintools/metric/_lfp.py
@@ -656,4 +656,12 @@ def lfp_phase_coherence(
     z = jnp.exp(1j * phases)                           # unit phasors
     # (i, j) = mean_t conj(z_i) z_j = mean_t exp(i(phi_j - phi_i)); |.| is the PLV.
     coherence = jnp.abs(jnp.conj(z).T @ z) / n_time
+    # PLV is the magnitude of a normalized sum of unit phasors, so it is
+    # mathematically bounded in [0, 1]. Clip to remove float32 roundoff that
+    # can push near-coherent pairs marginally above 1.0.
+    coherence = jnp.clip(coherence, 0.0, 1.0)
+    # A channel is perfectly phase-locked with itself, so the diagonal is
+    # exactly 1 by definition; set it explicitly to remove float32 drift that
+    # can leave it marginally below 1.0.
+    coherence = coherence.at[jnp.diag_indices(n_channels)].set(1.0)
     return coherence


### PR DESCRIPTION
## Summary

Fixes the CI failure on `main` where `TestLFPPhaseCoherence::test_phase_shifted_signals` failed on all three OS runners:

```
>       self.assertTrue(jnp.all(coherence_matrix <= 1.0))
E       AssertionError: Array(False, dtype=bool) is not true
braintools/metric/_lfp_test.py:346: AssertionError
```

## Root cause

`lfp_phase_coherence` returns a phase-locking value (PLV): the magnitude of a normalized sum of unit phasors. PLV is mathematically bounded in `[0, 1]` with an exactly-`1` diagonal. JAX defaults to **float32**, so accumulated roundoff over the time axis can:

- push near-coherent pairs marginally **above** `1.0` (≈`1.0001` for phase-shifted copies of the same sinusoid → the CI failure), and
- leave the **diagonal** marginally **below** `1.0` (≈`0.99998`, a latent fragility against `allclose(diag, 1.0)`).

## Fix

- Clip the coherence matrix to `[0, 1]` (provably valid — PLV cannot exceed those bounds).
- Set the diagonal to exactly `1.0` (a channel is perfectly phase-locked with itself by definition).

This aligns the implementation with its documented contract ("values in `[0, 1]`, diagonal exactly 1").

## Testing

- `braintools/metric/_lfp_test.py` — 44 passed (previously 1 failing).
- `braintools/metric/` — 332 passed, no regressions.

## Summary by Sourcery

Ensure LFP phase coherence outputs are numerically constrained to valid PLV bounds.

Bug Fixes:
- Clip the LFP phase coherence matrix to the [0, 1] range to prevent floating-point roundoff from producing values slightly above 1.
- Force the diagonal of the LFP phase coherence matrix to exactly 1 to avoid numerical drift below the theoretical PLV maximum for self-coherence.