### PR TITLE
fix(init): stop param() double-applying batch dim for callable initializers

### DIFF
--- a/braintools/init/_init_base.py
+++ b/braintools/init/_init_base.py
@@ -344,9 +344,17 @@ def param(
         return init
 
     # Check if the parameter is a callable function
+    #
+    # For a callable, the batch axis is incorporated by prepending it to ``sizes``
+    # and letting the initializer fill the full batched shape (so a random
+    # initializer draws independently per batch element). The shared trailing
+    # batch-expansion below must therefore NOT run again for this path, otherwise
+    # the batch axis is applied twice (``(batch, batch, *sizes)``).
+    batch_applied_by_callable = False
     if callable(init):
         if batch_size is not None:
             sizes = (batch_size,) + sizes
+            batch_applied_by_callable = True
         init = init(sizes, **param_kwargs)
     else:
         # Check if the parameter is a scalar value
@@ -366,7 +374,7 @@ def param(
 
     # Expand the parameter to match the given batch size
     param_value = init.value if isinstance(init, State) else init
-    if batch_size is not None:
+    if batch_size is not None and not batch_applied_by_callable:
         if param_value.ndim <= len(sizes):
             # add a new axis to the params so that it matches the dimensionality of the given shape ``sizes``
             param_value = _expand_params_to_match_sizes(param_value, sizes)

--- a/braintools/init/_init_base_test.py
+++ b/braintools/init/_init_base_test.py
@@ -741,6 +741,59 @@ class TestParamBatching:
             param(np.ones((4, 5)), 5, batch_size=3)
 
 
+class TestParamCallableBatching:
+    """param() batch_size for callable / Initialization initializers.
+
+    Regression for the double-batching bug: a callable initializer with
+    ``batch_size`` must yield exactly ``(batch_size, *sizes)`` -- not
+    ``(batch_size, batch_size, *sizes)``.
+    """
+
+    def test_callable_with_batch_size_1d(self):
+        """A callable gains a single leading batch axis."""
+        result = param(SimpleInit(5.0), 3, batch_size=4)
+        assert u.math.shape(result) == (4, 3)
+        assert np.all(np.asarray(result) == 5.0)
+
+    def test_callable_with_batch_size_2d(self):
+        """A callable with 2-D sizes gains exactly one leading batch axis."""
+        result = param(SimpleInit(5.0), (3, 4), batch_size=2)
+        assert u.math.shape(result) == (2, 3, 4)
+        assert np.all(np.asarray(result) == 5.0)
+
+    def test_callable_quantity_with_batch_size(self):
+        """A callable returning a Quantity keeps its unit and batched shape."""
+        result = param(QuantityInit(2.0 * u.nS), 3, batch_size=4)
+        assert u.math.shape(result) == (4, 3)
+        assert u.get_unit(result) == u.nS
+        assert np.all(result.to_decimal(u.nS) == 2.0)
+
+    def test_callable_batch_size_none_unchanged(self):
+        """batch_size=None leaves the callable result un-batched."""
+        result = param(SimpleInit(5.0), 3, batch_size=None)
+        assert u.math.shape(result) == (3,)
+
+    def test_callable_random_independent_per_batch(self):
+        """A random initializer draws independently for each batch element."""
+        rng = np.random.default_rng(0)
+        result = param(RandomInit(0.0, 1.0), 3, batch_size=4, rng=rng)
+        assert u.math.shape(result) == (4, 3)
+        arr = np.asarray(result)
+        # Independent draws => batch rows must not all be identical.
+        assert not np.allclose(arr[0], arr[1])
+
+    def test_callable_forwards_kwargs_with_batch_size(self):
+        """**param_kwargs still reach the callable when batching."""
+
+        class KwargsInit(Initialization):
+            def __call__(self, size, fill=None, **kwargs):
+                return np.full(size, fill)
+
+        result = param(KwargsInit(), 3, batch_size=4, fill=7.0)
+        assert u.math.shape(result) == (4, 3)
+        assert np.all(np.asarray(result) == 7.0)
+
+
 class TestPipeInitRejectsInitialization:
     """PipeInit cannot pipe values into an Initialization right operand (bug H3)."""
 


### PR DESCRIPTION
## Problem

`braintools.init.param(init, sizes, batch_size)` returns a tensor with a **doubled** batch dimension `(batch, batch, *sizes)` when `init` is a callable / `Initialization` and `batch_size` is given.

```python
import brainunit as u, braintools
braintools.init.param(braintools.init.Constant(-65.0 * u.mV), (3,), 4)
# expected: (4, 3)
# actual:   (4, 4, 3)
```

Surfaced via downstream `braincell` CI: `SingleCompartment.init_state(batch_size=4)` produced `V` of shape `(4, 4, 3)` instead of `(4, 3)`, failing on every OS / jax version.

## Root cause

The callable branch incorporates the batch axis by prepending it to `sizes` and letting the initializer fill the full batched shape (so a random initializer draws independently per batch element). The **shared** trailing batch-expansion block — meant only for the array/`Quantity`/`State`/`Param` paths, which do not pre-apply batch — then ran again and repeated the axis a second time.

## Fix

Track whether the callable branch already applied the batch axis and skip the trailing expansion in that case. Array/`Quantity`/`State`/`Param` paths are unchanged.

## Tests

New `TestParamCallableBatching`: 1-D, 2-D, `Quantity`, `batch_size=None`, independent random draws (rows not all identical), and `**param_kwargs` forwarding.

- `braintools/init/` suite: 358 passed.
- Downstream full `braincell` suite against the patched build: 2004 passed, 0 failed, 26 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix param() batching for callable initializers to avoid double-applying the batch dimension and add regression coverage for callable batching behavior.

Bug Fixes:
- Ensure callable/Initialization initializers with batch_size produce tensors of shape (batch_size, *sizes) instead of duplicating the batch axis.

Tests:
- Add regression tests validating param() batching for callable and Initialization initializers, including quantities, random draws, batch_size=None, and kwargs forwarding.