### PR TITLE
fix(init): correct TruncatedNormal array std, param() State handling & docs

### DIFF
--- a/braintools/init/_init_base.py
+++ b/braintools/init/_init_base.py
@@ -87,9 +87,13 @@ class Initialization(ABC):
         >>>
         >>> delay_init = Uniform(1.0 * u.ms, 3.0 * u.ms).clip(0.5 * u.ms, 5.0 * u.ms)
         >>>
+        >>> # Each transform must be parenthesized: a bare ``lambda`` body would
+        >>> # greedily capture the rest of the expression. Bounds must share the
+        >>> # value's unit (``0.0 * u.nS``, not ``0``).
         >>> combined = (Normal(1.0 * u.nS, 0.2 * u.nS) |
-        ...             lambda x: x.clip(0, 2 * u.nS) |
-        ...             lambda x: x * 0.5)
+        ...             (lambda x: u.math.maximum(x, 0.0 * u.nS)) |
+        ...             (lambda x: x * 0.5))
+        >>> values = combined(1000, rng=np.random.default_rng(0))
     """
     __module__ = 'braintools.init'
 
@@ -365,15 +369,19 @@ def param(
         else:
             raise TypeError(f'Unknown parameter type: {type(init)}')
 
+    # Resolve the underlying value first: a ``State`` is a mutable container and
+    # ``u.math.shape(state)`` reports ``()`` (it does not see into the wrapped
+    # value), which would silently bypass the shape check below.
+    param_value = init.value if isinstance(init, State) else init
+
     # Check if the shape of the parameter matches the given size
-    if not _are_broadcastable_shapes(u.math.shape(init), sizes):
+    if not _are_broadcastable_shapes(u.math.shape(param_value), sizes):
         raise ValueError(
-            f'The shape of the parameter {u.math.shape(init)} '
+            f'The shape of the parameter {u.math.shape(param_value)} '
             f'does not match with the given size {sizes}'
         )
 
     # Expand the parameter to match the given batch size
-    param_value = init.value if isinstance(init, State) else init
     if batch_size is not None and not batch_applied_by_callable:
         if param_value.ndim <= len(sizes):
             # add a new axis to the params so that it matches the dimensionality of the given shape ``sizes``
@@ -383,15 +391,19 @@ def param(
                 batch_size,
                 axis=0
             )
-            if isinstance(init, State):
-                init.restore_value(param_value)
-                param_value = init
         else:
             if param_value.shape[0] != batch_size:
                 raise ValueError(
                     f'The batch size of the parameter {param_value.shape[0]} '
                     f'does not match with the given batch size {batch_size}'
                 )
+    # A ``State`` input is a mutable container: update its value and return the
+    # container itself, consistent with the ``Param`` path above and the
+    # documented contract. Doing this only in the batch-expansion branch (the
+    # previous behaviour) made the return type depend on the batch shape.
+    if isinstance(init, State):
+        init.restore_value(param_value)
+        return init
     return param_value
 
 

--- a/braintools/init/_init_base_test.py
+++ b/braintools/init/_init_base_test.py
@@ -709,6 +709,50 @@ class TestParamSupport:
             param(p, 5, batch_size=3)
 
 
+class TestParamStateSupport:
+    """param() must return the State (value updated) consistently (bug B2).
+
+    Previously the no-batch and already-batched paths returned the bare
+    underlying value, while only the batch-expansion path returned the State.
+    """
+
+    def test_state_no_batch_returns_state(self):
+        from brainstate import State
+        s = State(np.ones(10) * u.nS)
+        result = param(s, 10)
+        assert isinstance(result, State)
+        assert result is s
+        assert u.math.shape(result.value) == (10,)
+
+    def test_state_batch_expand_returns_state(self):
+        from brainstate import State
+        s = State(np.ones(10) * u.nS)
+        result = param(s, 10, batch_size=4)
+        assert isinstance(result, State)
+        assert result is s
+        assert u.math.shape(result.value) == (4, 10)
+
+    def test_state_already_batched_returns_state(self):
+        from brainstate import State
+        s = State(np.ones((4, 10)) * u.nS)
+        result = param(s, 10, batch_size=4)
+        assert isinstance(result, State)
+        assert result is s
+        assert u.math.shape(result.value) == (4, 10)
+
+    def test_state_batch_mismatch_raises(self):
+        from brainstate import State
+        s = State(np.ones((3, 10)) * u.nS)
+        with pytest.raises(ValueError, match="batch size"):
+            param(s, 10, batch_size=4)
+
+    def test_state_shape_mismatch_raises(self):
+        from brainstate import State
+        s = State(np.ones(10) * u.nS)
+        with pytest.raises(ValueError, match="does not match"):
+            param(s, 5)
+
+
 class TestParamBatching:
     """Test param() batch_size expansion for plain arrays/quantities (bug C2)."""
 

--- a/braintools/init/_init_basic.py
+++ b/braintools/init/_init_basic.py
@@ -482,21 +482,27 @@ class TruncatedNormal(Initialization):
         lo = None if self.low is None else u.Quantity(self.low).to(unit).mantissa
         hi = None if self.high is None else u.Quantity(self.high).to(unit).mantissa
 
-        if std == 0:
-            # Degenerate distribution: all mass at the (clamped) mean.
-            samples = jnp.full(size, mean, dtype=float)
-        else:
-            a = -jnp.inf if lo is None else (lo - mean) / std
-            b = jnp.inf if hi is None else (hi - mean) / std
-            # Inverse-CDF sampling: draw u ~ U(0, 1), map into the truncated CDF
-            # interval [F(a), F(b)], then invert through the normal quantile.
-            cdf_a = 0.0 if lo is None else ndtr(a)
-            cdf_b = 1.0 if hi is None else ndtr(b)
-            u_samples = rng.uniform(0.0, 1.0, size)
-            p = cdf_a + u_samples * (cdf_b - cdf_a)
-            # Keep the quantile finite (avoids +-inf at the open ends).
-            p = jnp.clip(p, 1e-7, 1.0 - 1e-7)
-            samples = mean + std * ndtri(p)
+        # Vectorized inverse-CDF sampling that also handles a degenerate (std == 0)
+        # distribution element-wise. A scalar ``if std == 0`` would raise
+        # ("truth value ambiguous") for array-valued ``std`` (a per-element
+        # parametrization that the sibling distributions accept), so instead use a
+        # "safe" denominator: where ``std == 0`` the term ``std * ndtri(p)`` is 0,
+        # leaving ``samples == mean`` (then clamped into ``[low, high]`` below).
+        mean_arr = jnp.asarray(mean, dtype=float)
+        std_arr = jnp.asarray(std, dtype=float)
+        safe_std = jnp.where(std_arr == 0, 1.0, std_arr)
+
+        a = -jnp.inf if lo is None else (lo - mean_arr) / safe_std
+        b = jnp.inf if hi is None else (hi - mean_arr) / safe_std
+        # Inverse-CDF sampling: draw u ~ U(0, 1), map into the truncated CDF
+        # interval [F(a), F(b)], then invert through the normal quantile.
+        cdf_a = 0.0 if lo is None else ndtr(a)
+        cdf_b = 1.0 if hi is None else ndtr(b)
+        u_samples = rng.uniform(0.0, 1.0, size)
+        p = cdf_a + u_samples * (cdf_b - cdf_a)
+        # Keep the quantile finite (avoids +-inf at the open ends).
+        p = jnp.clip(p, 1e-7, 1.0 - 1e-7)
+        samples = mean_arr + std_arr * ndtri(p)
 
         if lo is not None or hi is not None:
             samples = jnp.clip(

--- a/braintools/init/_init_basic_test.py
+++ b/braintools/init/_init_basic_test.py
@@ -480,6 +480,64 @@ class TestTruncatedNormalBackend(unittest.TestCase):
         self.assertAlmostEqual(float(np.mean(weights.mantissa)), 0.5, delta=0.02)
 
 
+class TestTruncatedNormalArrayParams(unittest.TestCase):
+    """TruncatedNormal must accept array-valued ``mean``/``std`` (bug B1).
+
+    A scalar ``if std == 0`` previously raised "truth value of an array ...
+    is ambiguous" for per-element ``std``.
+    """
+
+    def test_array_std_does_not_crash(self):
+        rng = np.random.default_rng(0)
+        init = TruncatedNormal(
+            mean=np.array([0.0, 1.0]) * u.mV,
+            std=np.array([0.5, 0.2]) * u.mV,
+            low=-1.0 * u.mV, high=2.0 * u.mV,
+        )
+        weights = init(2, rng=rng)
+        self.assertEqual(weights.shape, (2,))
+        self.assertTrue(np.all(weights >= -1.0 * u.mV))
+        self.assertTrue(np.all(weights <= 2.0 * u.mV))
+
+    def test_array_std_with_zero_element_is_degenerate(self):
+        """A zero entry in ``std`` collapses that element to the (clamped) mean."""
+        rng = np.random.default_rng(0)
+        init = TruncatedNormal(
+            mean=np.array([0.5, 3.0]) * u.mV,
+            std=np.array([0.0, 0.2]) * u.mV,
+            low=0.0 * u.mV, high=1.0 * u.mV,
+        )
+        weights = init(2, rng=rng)
+        # std==0 with in-range mean -> exactly the mean.
+        self.assertAlmostEqual(float(weights.mantissa[0]), 0.5, places=6)
+        # std==0 path must not perturb the second (non-zero std) element's bounds.
+        self.assertTrue(0.0 <= float(weights.mantissa[1]) <= 1.0)
+
+    def test_scalar_std_zero_still_degenerate(self):
+        """Scalar std==0 keeps the original degenerate behaviour (all == mean)."""
+        rng = np.random.default_rng(0)
+        init = TruncatedNormal(0.5 * u.mV, 0.0 * u.mV, low=0.0 * u.mV, high=1.0 * u.mV)
+        weights = init(5, rng=rng)
+        self.assertTrue(np.allclose(weights.mantissa, 0.5))
+
+    def test_scalar_std_zero_mean_out_of_range_is_clamped(self):
+        rng = np.random.default_rng(0)
+        init = TruncatedNormal(5.0 * u.mV, 0.0 * u.mV, low=0.0 * u.mV, high=1.0 * u.mV)
+        weights = init(3, rng=rng)
+        self.assertTrue(np.allclose(weights.mantissa, 1.0))
+
+    def test_array_mean_and_std_statistics(self):
+        """Per-element parametrization keeps each element near its own mean."""
+        rng = np.random.default_rng(0)
+        means = np.array([0.2, 0.8]) * u.mV
+        init = TruncatedNormal(mean=means, std=np.array([0.05, 0.05]) * u.mV,
+                               low=0.0 * u.mV, high=1.0 * u.mV)
+        weights = init((100000, 2), rng=rng)
+        col_means = np.mean(weights.mantissa, axis=0)
+        self.assertAlmostEqual(float(col_means[0]), 0.2, delta=0.02)
+        self.assertAlmostEqual(float(col_means[1]), 0.8, delta=0.02)
+
+
 class TestEdgeCases(unittest.TestCase):
     def setUp(self):
         self.rng = np.random.default_rng(42)

--- a/braintools/init/_init_orthogonal.py
+++ b/braintools/init/_init_orthogonal.py
@@ -77,7 +77,8 @@ class Orthogonal(Initialization):
         if unit is not None:
             warnings.warn(
                 'The `unit` parameter is deprecated and will be removed in future versions. '
-                'Please handle units separately from initialization.', DeprecationWarning
+                'Please handle units separately from initialization.',
+                DeprecationWarning, stacklevel=2,
             )
         else:
             unit = u.UNITLESS
@@ -162,7 +163,8 @@ class DeltaOrthogonal(Initialization):
         if unit is not None:
             warnings.warn(
                 'The `unit` parameter is deprecated and will be removed in future versions. '
-                'Please handle units separately from initialization.', DeprecationWarning
+                'Please handle units separately from initialization.',
+                DeprecationWarning, stacklevel=2,
             )
         else:
             unit = u.UNITLESS
@@ -208,6 +210,17 @@ class Identity(Initialization):
     ----------
     scale : float, optional
         Multiplicative factor to apply to the identity matrix (default: 1.0).
+
+    Notes
+    -----
+    The output depends on the rank of ``size``:
+
+    - **1-D** ``(n,)``: an identity matrix is undefined, so a vector of
+      ``scale * ones(n)`` is returned (useful as a bias-like / pass-through init).
+    - **2-D** ``(rows, cols)``: ``scale * eye(rows, cols)`` (identity, truncated
+      or zero-padded for rectangular shapes).
+    - **N-D**: ``scale`` times an identity placed in the trailing two dimensions,
+      broadcast over the leading dimensions.
 
     Examples
     --------

--- a/braintools/init/_init_orthogonal_test.py
+++ b/braintools/init/_init_orthogonal_test.py
@@ -248,5 +248,31 @@ class TestIdentity(unittest.TestCase):
         self.assertIn('2.0', repr_str)
 
 
+class TestUnitDeprecationWarning(unittest.TestCase):
+    """The deprecated ``unit=`` arg must warn at the caller's stack frame (bug D4)."""
+
+    def test_orthogonal_unit_warns_at_caller(self):
+        import warnings
+        import brainunit as u
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            Orthogonal(unit=u.nS)
+        self.assertEqual(len(caught), 1)
+        self.assertTrue(issubclass(caught[0].category, DeprecationWarning))
+        # stacklevel=2 attributes the warning to this test module, not the
+        # library source file.
+        self.assertTrue(caught[0].filename.endswith('_init_orthogonal_test.py'))
+
+    def test_delta_orthogonal_unit_warns_at_caller(self):
+        import warnings
+        import brainunit as u
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            DeltaOrthogonal(unit=u.nS)
+        self.assertEqual(len(caught), 1)
+        self.assertTrue(issubclass(caught[0].category, DeprecationWarning))
+        self.assertTrue(caught[0].filename.endswith('_init_orthogonal_test.py'))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/braintools/init/_init_variance_scaling.py
+++ b/braintools/init/_init_variance_scaling.py
@@ -185,6 +185,11 @@ class KaimingUniform(VarianceScaling):
 
     Parameters
     ----------
+    scale : float, optional
+        Variance multiplier (``variance = scale / fan``). When ``None`` (the
+        default), it is derived from ``nonlinearity`` as the He variance
+        multiplier ``gain ** 2`` (``2.0`` for ReLU, ``2 / (1 + negative_slope ** 2)``
+        for leaky ReLU). Pass an explicit value to override.
     mode : {'fan_in', 'fan_out', 'fan_avg'}, optional
         Mode for computing scale factor (default: 'fan_in').
     nonlinearity : {'relu', 'leaky_relu'}, optional
@@ -246,6 +251,11 @@ class KaimingNormal(VarianceScaling):
 
     Parameters
     ----------
+    scale : float, optional
+        Variance multiplier (``variance = scale / fan``). When ``None`` (the
+        default), it is derived from ``nonlinearity`` as the He variance
+        multiplier ``gain ** 2`` (``2.0`` for ReLU, ``2 / (1 + negative_slope ** 2)``
+        for leaky ReLU). Pass an explicit value to override.
     mode : {'fan_in', 'fan_out', 'fan_avg'}, optional
         Mode for computing scale factor (default: 'fan_in').
     nonlinearity : {'relu', 'leaky_relu'}, optional

--- a/docs/braintools-init-issues-found-20260618.md
+++ b/docs/braintools-init-issues-found-20260618.md
@@ -1,0 +1,253 @@
+# `braintools.init` — Issues Found & Proposed Solutions (2026-06-18)
+
+This document records issues identified during a senior-developer / JAX-expert
+review of the `braintools/init/` module and its documentation, together with the
+solutions applied. Each issue lists a minimal reproduction, the root cause, and
+the fix.
+
+The module had already been audited previously (the source contains references
+to earlier fixes such as `bug C1` and `bug H2/M8`); the issues below are the
+*remaining* defects found in this pass. All findings were verified empirically
+before fixing, and regression tests were added for every behavioural change.
+
+Severity legend: **High** = wrong result / crash on a documented use case;
+**Medium** = crash on a reasonable edge case or contract violation;
+**Low** = documentation / cosmetic.
+
+---
+
+## B1 (High) — `TruncatedNormal` crashes on array-valued `std`
+
+**File:** `braintools/init/_init_basic.py` — `TruncatedNormal.__call__`
+
+**Symptom**
+
+```python
+import numpy as np, brainunit as u
+from braintools.init import TruncatedNormal
+init = TruncatedNormal(
+    mean=np.array([0., 1.]) * u.mV,
+    std=np.array([0.5, 0.2]) * u.mV,
+    low=-1. * u.mV, high=2. * u.mV,
+)
+init(2, rng=np.random.default_rng(0))
+# ValueError: The truth value of an array with more than one element is ambiguous.
+```
+
+**Root cause**
+
+The degenerate-distribution shortcut used a scalar comparison:
+
+```python
+if std == 0:
+    samples = jnp.full(size, mean, dtype=float)
+else:
+    ...
+```
+
+When `std` is an array (a legitimate per-element parametrization that every
+sibling distribution — `Normal`, `LogNormal`, … — accepts), `std == 0` is an
+array and `if` raises `ValueError: truth value ... ambiguous`. Even when no
+element is zero, the code path is unreachable for arrays.
+
+**Fix**
+
+Vectorize the computation so the `std == 0` case is handled element-wise via a
+"safe" denominator, removing the scalar `if`:
+
+```python
+mean_arr = jnp.asarray(mean, dtype=float)
+std_arr = jnp.asarray(std, dtype=float)
+# Avoid divide-by-zero in the standardized bounds; std==0 contributes 0 below.
+safe_std = jnp.where(std_arr == 0, 1.0, std_arr)
+a = -jnp.inf if lo is None else (lo - mean_arr) / safe_std
+b =  jnp.inf if hi is None else (hi - mean_arr) / safe_std
+cdf_a = 0.0 if lo is None else ndtr(a)
+cdf_b = 1.0 if hi is None else ndtr(b)
+p = jnp.clip(cdf_a + rng.uniform(0., 1., size) * (cdf_b - cdf_a), 1e-7, 1. - 1e-7)
+samples = mean_arr + std_arr * ndtri(p)   # std==0 -> exactly mean
+```
+
+For `std == 0` the term `std_arr * ndtri(p)` is `0`, so `samples == mean`, then
+the existing clip to `[low, high]` clamps the mean into range — identical to the
+previous scalar behaviour, now also correct for arrays and mixed (some-zero)
+`std`.
+
+---
+
+## B2 (Medium) — `param()` returns inconsistent types for `State` inputs
+
+**File:** `braintools/init/_init_base.py` — `param`
+
+**Symptom**
+
+```python
+import numpy as np, brainunit as u
+from brainstate import State
+from brainstate.nn import Param
+from braintools.init import param
+
+param(State(np.ones(10) * u.nS), 10)                       # -> Quantity (bare value!)
+param(State(np.ones((4, 10)) * u.nS), 10, batch_size=4)    # -> Quantity (bare value!)
+param(Param(np.ones((3, 5))),       5,  batch_size=3)      # -> Param  (container)
+```
+
+The `param` docstring states: *"`State`/`Param` inputs are returned with their
+value updated."* The `Param` path honours this (always returns the `Param`), but
+the `State` path only returns the `State` in the single sub-case where a batch
+axis must be *expanded*; in the no-batch and already-batched sub-cases it returns
+the bare underlying value. The return type therefore depends on the batch shape,
+which is surprising and contradicts the documented contract.
+
+**Root cause**
+
+`State` was wrapped back into the container (`init.restore_value(...)`) only
+inside the `param_value.ndim <= len(sizes)` branch:
+
+```python
+param_value = init.value if isinstance(init, State) else init
+if batch_size is not None and not batch_applied_by_callable:
+    if param_value.ndim <= len(sizes):
+        ...
+        if isinstance(init, State):
+            init.restore_value(param_value)
+            param_value = init        # <- only here
+    else:
+        ...                           # already-batched: never re-wraps
+return param_value                    # <- no-batch: returns bare value
+```
+
+**Fix**
+
+Hoist the `State` re-wrap out of the batch-expansion branch so every path
+updates the `State`'s value and returns the `State`, mirroring the `Param` path:
+
+```python
+if batch_size is not None and not batch_applied_by_callable:
+    if param_value.ndim <= len(sizes):
+        param_value = _expand_params_to_match_sizes(param_value, sizes)
+        param_value = u.math.repeat(u.math.expand_dims(param_value, 0), batch_size, axis=0)
+    else:
+        if param_value.shape[0] != batch_size:
+            raise ValueError(...)
+if isinstance(init, State):
+    init.restore_value(param_value)
+    return init
+return param_value
+```
+
+Additionally, the shape-compatibility check ran on `u.math.shape(init)` with
+`init` being the `State` *wrapper*, which reports `()` (it does not see into the
+wrapped value). As a result the check `_are_broadcastable_shapes((), sizes)`
+always passed, so a `State` whose value shape disagreed with `sizes` was *not*
+rejected (e.g. `param(State(ones(10) * u.nS), 5)` silently succeeded). The fix
+resolves the underlying value *before* the shape check and validates
+`u.math.shape(param_value)`.
+
+**Risk:** low. The only in-tree callers of `param` (`braintools.conn`) pass
+`Initialization` objects or scalars, never a `State`, and there were no existing
+tests for the `State` path.
+
+---
+
+## D1 (Medium) — Broken pipe example in `Initialization` docstring
+
+**File:** `braintools/init/_init_base.py` — `Initialization` class docstring
+
+**Problem**
+
+```python
+>>> combined = (Normal(1.0 * u.nS, 0.2 * u.nS) |
+...             lambda x: x.clip(0, 2 * u.nS) |
+...             lambda x: x * 0.5)
+```
+
+Two defects:
+
+1. **Operator precedence.** A bare `lambda` body extends as far right as
+   possible, so this parses as
+   `Normal(...) | (lambda x: x.clip(0, 2*u.nS) | (lambda x: x * 0.5))`.
+   When evaluated, the lambda body computes `array | function`, a bitwise-or
+   between an array and a callable → `TypeError`. The intended left-to-right
+   pipe is not built.
+2. **Unit mismatch.** `x` carries `nS`, so `x.clip(0, 2 * u.nS)` mixes a
+   unitless `0` with a `nS` bound → `UnitMismatchError`.
+
+The example only *constructs* the object (it is never called in the docstring),
+so doctest does not flag it, yet it is wrong and misleads users.
+
+**Fix**
+
+Parenthesize each lambda and use unit-consistent, executable transforms:
+
+```python
+>>> combined = (Normal(1.0 * u.nS, 0.2 * u.nS) |
+...             (lambda x: u.math.maximum(x, 0.0 * u.nS)) |
+...             (lambda x: x * 0.5))
+>>> values = combined(1000, rng=np.random.default_rng(0))
+```
+
+---
+
+## D2 (Low) — `KaimingUniform` / `KaimingNormal` omit the `scale` parameter in docs
+
+**File:** `braintools/init/_init_variance_scaling.py`
+
+Both `__init__` accept a leading `scale` argument (default `None`, computed from
+`nonlinearity`), but their **Parameters** sections list only `mode`,
+`nonlinearity`, and `negative_slope`. The fix documents `scale` and clarifies
+that, when `None`, it defaults to the He variance multiplier (`gain ** 2`, i.e.
+`2.0` for ReLU).
+
+---
+
+## D3 (Low) — `Identity` 1D behaviour undocumented
+
+**File:** `braintools/init/_init_orthogonal.py` — `Identity`
+
+For a 1-D shape there is no identity matrix, so `Identity` returns a vector of
+`scale * ones`. This is reasonable (bias-like) but was undocumented. The fix adds
+a **Notes** section describing the 1-D, 2-D, and N-D behaviour.
+
+---
+
+## D4 (Low) — `Orthogonal` / `DeltaOrthogonal` deprecation warning has wrong `stacklevel`
+
+**File:** `braintools/init/_init_orthogonal.py`
+
+`Orthogonal(unit=...)` and `DeltaOrthogonal(unit=...)` emit a `DeprecationWarning`
+with the default `stacklevel=1`, so the warning is attributed to
+`_init_orthogonal.py` rather than the user's call site. The shared helper
+`_resolve_deprecated_unit` in `_init_basic.py` correctly uses an elevated
+`stacklevel`. The fix sets `stacklevel=2` so the warning points at user code.
+
+---
+
+## Items reviewed and found correct (no change)
+
+To document the scope of the review, the following were checked and confirmed
+correct:
+
+- **Variance-scaling math.** Kaiming (`scale = gain**2`, `variance = scale/fan`),
+  Xavier (`fan_avg`, `Var = 2/(fan_in+fan_out)`), and LeCun (`fan_in`,
+  `Var = 1/fan_in`) all match their references; the truncated-normal variant
+  rescales by the truncated-normal stddev constant to hit the target variance.
+- **Distribution parametrizations.** `LogNormal` (linear-space mean/std →
+  log-space `mu`/`sigma`), `Gamma`, `Weibull`, `Beta` (rescaled to `[low, high]`),
+  and `Exponential` are parametrized correctly.
+- **Default RNG backend.** Every distribution works with the default
+  `brainstate.random` backend as well as a passed NumPy `Generator`.
+- **Unit handling.** `Clipped` / `.clip()` correctly branch on unitless vs
+  unit-carrying values (the earlier `H2/M8` fix); `Mixture` / `Conditional`
+  reconcile component units and raise on incompatibility.
+- **Profile arithmetic.** `ComposedProfile._evaluate`'s `isinstance(obj,
+  ArrayLike)` check works on this toolchain (Python `typing.Union` isinstance).
+- **Composition guards.** `PipeInit` / `PipeProfile` / `Compose` raise clear
+  `TypeError`s when an `Initialization`/`DistanceProfile` is used where a plain
+  transform is expected.
+
+Note (by design, not changed): several profiles (`BimodalProfile`, and
+`DoGProfile`/`MexicanHatProfile` before their non-negativity clip) can return
+values `> 1`. They are *weight-scaling* profiles, so this is intentional; the
+downstream connectivity sampler in `braintools.conn` is responsible for
+interpreting `probability()` as a sampling probability.


### PR DESCRIPTION
## Summary

Senior-developer / JAX-expert audit of `braintools/init/` and its documentation. Found and fixed two correctness bugs plus several documentation defects. Full findings (with reproductions) in `docs/braintools-init-issues-found-20260618.md`.

## Fixes

**Bugs**
- **`TruncatedNormal` crashed on array-valued `std`.** The scalar `if std == 0` raised `ValueError: truth value ... ambiguous` for per-element `std` (a parametrization every sibling distribution accepts). Vectorized the degenerate-std handling with a "safe" denominator; scalar `std == 0` keeps its degenerate-at-(clamped)-mean behaviour.
- **`param()` returned inconsistent types for `State` inputs.** The no-batch and already-batched paths returned the bare value while only the batch-expansion path returned the `State`, contradicting the docstring and the `Param` path. Now returns the `State` (value updated) in all paths. Also fixed the shape check, which ran on `u.math.shape(state)` (`== ()`) and silently bypassed validation for `State` inputs.

**Documentation**
- Fixed the malformed / unit-mismatched pipe example in `Initialization` (lambda precedence + `clip(0, 2*u.nS)` unit mismatch).
- Documented the `scale` parameter for `KaimingUniform` / `KaimingNormal`.
- Documented `Identity` 1-D behaviour (returns `scale * ones`).
- Fixed the `Orthogonal` / `DeltaOrthogonal` deprecation-warning `stacklevel` so it points at the caller.

## Tests

- Added 12 regression tests (array/zero `std`, `param()`+`State` across all batch paths, deprecation-warning stack frame).
- Full `braintools/init` suite: **370 passed** (was 358). `braintools/conn` `param` consumers: 97 passed (no regression).

## Summary by Sourcery

Audit and correct core initialization utilities, improving robustness of truncated normal sampling, parameter handling, and documentation clarity.

Bug Fixes:
- Allow TruncatedNormal to handle array-valued std, including zero elements, without crashing while preserving degenerate-at-mean behavior for zero std.
- Make param() consistently validate shapes based on underlying values and always return updated State containers for State inputs.
- Ensure Orthogonal and DeltaOrthogonal deprecation warnings are reported at the caller site via an appropriate warning stack level.

Enhancements:
- Clarify Initialization piping example to be syntactically correct, unit-consistent, and executable.
- Document the scale parameter semantics for KaimingUniform and KaimingNormal initializers.
- Document Identity initializer behavior across 1-D, 2-D, and higher-rank shapes.

Documentation:
- Add an audit document detailing issues found in braintools.init and their resolutions.
- Expand and correct inline documentation for initialization behaviors and parameters, including Identity and Kaiming variants.

Tests:
- Add regression tests for TruncatedNormal with array and zero std, param() behavior with State across batch scenarios, and deprecation-warning stack frames for Orthogonal and DeltaOrthogonal.