### PR TITLE
fix(visualize): resolve audit issues, add regression tests (>90% cov)

### DIFF
--- a/braintools/visualize/__init__.py
+++ b/braintools/visualize/__init__.py
@@ -63,8 +63,8 @@ analysis, 3D visualization, and interactive dashboards.
     # Define network architecture
     layer_sizes = [784, 256, 128, 10]
 
-    # Visualize network structure
-    fig, ax = neural_network_3d(
+    # Visualize network structure (returns the 3D Axes)
+    ax = neural_network_3d(
         layer_sizes=layer_sizes,
         layer_spacing=2.0,
         node_size=100,

--- a/braintools/visualize/_audit_20260619_test.py
+++ b/braintools/visualize/_audit_20260619_test.py
@@ -1,0 +1,356 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Regression tests for the 2026-06-19 ``braintools.visualize`` audit fixes.
+
+Each test pins a specific bug found and fixed during the audit; see
+``docs/braintools-visualize-issues-found-20260619.md``.
+"""
+
+import unittest
+import warnings
+
+import matplotlib
+import numpy as np
+
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+from braintools.visualize import (
+    line_plot, animate_1D, animate_2D,
+    spike_raster, neural_trajectory,
+    correlation_matrix, regression_plot, confusion_matrix, roc_curve,
+    brain_surface_3d, volume_rendering, neural_network_3d,
+)
+
+
+def _draw(ax):
+    """Force a canvas draw so deferred matplotlib validation (e.g. scatter
+    color/size mismatches) actually raises."""
+    ax.figure.canvas.draw()
+
+
+class TestLinePlotConversion(unittest.TestCase):
+    """Issue 1: ``line_plot`` reshaped before converting -> crashed on lists."""
+
+    def tearDown(self):
+        plt.close('all')
+
+    def test_nested_list_val_matrix(self):
+        # Previously raised AttributeError: 'list' object has no attribute 'reshape'
+        ax = line_plot(list(range(5)), [[1], [2], [3], [4], [5]], plot_ids=[0])
+        self.assertEqual(len(ax.get_lines()), 1)
+
+    def test_flat_list_inputs(self):
+        ax = line_plot([0, 1, 2], [1.0, 2.0, 3.0], plot_ids=[0])
+        self.assertEqual(len(ax.get_lines()), 1)
+
+    def test_ndarray_still_works(self):
+        ax = line_plot(np.arange(10), np.random.randn(10, 3), plot_ids=[0, 1, 2])
+        self.assertEqual(len(ax.get_lines()), 3)
+
+
+class TestSpikeRasterColorFiltering(unittest.TestCase):
+    """Issue 2: a per-spike ``color`` array was not filtered with the spikes."""
+
+    def tearDown(self):
+        plt.close('all')
+
+    def test_array_color_with_time_range(self):
+        st = np.linspace(0, 100, 50)
+        nid = np.arange(50) % 10
+        colors = np.linspace(0, 1, 50)
+        ax = spike_raster(st, nid, color=colors, time_range=(0, 50))
+        _draw(ax)  # must not raise a length-mismatch error
+
+    def test_array_color_with_neuron_range(self):
+        st = np.linspace(0, 100, 50)
+        nid = np.arange(50) % 10
+        colors = np.linspace(0, 1, 50)
+        ax = spike_raster(st, nid, color=colors, neuron_range=(0, 4))
+        _draw(ax)
+
+    def test_array_color_with_both_filters(self):
+        st = np.linspace(0, 100, 50)
+        nid = np.arange(50) % 10
+        colors = np.linspace(0, 1, 50)
+        ax = spike_raster(st, nid, color=colors, time_range=(10, 90), neuron_range=(0, 5))
+        _draw(ax)
+
+    def test_string_color_with_filter_unaffected(self):
+        st = np.linspace(0, 100, 50)
+        nid = np.arange(50) % 10
+        ax = spike_raster(st, nid, color='red', time_range=(0, 50))
+        _draw(ax)
+
+
+class TestAnimate1DNoMutation(unittest.TestCase):
+    """Issue 3: ``animate_1D`` mutated the caller's input dictionaries."""
+
+    def tearDown(self):
+        plt.close('all')
+
+    def test_single_dict_not_mutated(self):
+        d = {'ys': np.random.rand(10, 20)}
+        before = set(d)
+        animate_1D(d, show=False)
+        self.assertEqual(set(d), before)
+
+    def test_list_of_dicts_not_mutated(self):
+        v = [{'ys': np.random.rand(5, 8), 'legend': 'a'}]
+        before = set(v[0])
+        animate_1D(v, show=False)
+        self.assertEqual(set(v[0]), before)
+        self.assertEqual(v[0]['legend'], 'a')
+
+    def test_ndarray_input_works(self):
+        fig = animate_1D(np.random.rand(6, 12), show=False)
+        self.assertIsNotNone(fig)
+
+    def test_unknown_dynamic_type_raises(self):
+        with self.assertRaises(ValueError):
+            animate_1D("not-an-array", show=False)
+
+
+class TestConfusionMatrixNormalization(unittest.TestCase):
+    """Issue 4: normalization divided by zero -> NaN for absent classes."""
+
+    def tearDown(self):
+        plt.close('all')
+
+    def _assert_no_nan(self, normalize):
+        y_true = np.array([0, 1, 2, 2, 1, 0])
+        y_pred = np.array([0, 1, 1, 1, 1, 0])  # class 2 never predicted
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', RuntimeWarning)
+            ax = confusion_matrix(y_true, y_pred, normalize=normalize)
+        im = ax.get_images()[0]
+        self.assertFalse(np.isnan(im.get_array()).any())
+
+    def test_normalize_pred(self):
+        self._assert_no_nan('pred')
+
+    def test_normalize_true(self):
+        self._assert_no_nan('true')
+
+    def test_normalize_all(self):
+        self._assert_no_nan('all')
+
+    def test_normalize_true_rows_sum_to_one(self):
+        y_true = np.array([0, 0, 1, 1, 2, 2])
+        y_pred = np.array([0, 1, 1, 1, 2, 0])
+        ax = confusion_matrix(y_true, y_pred, normalize='true')
+        cm = ax.get_images()[0].get_array()
+        np.testing.assert_allclose(cm.sum(axis=1), np.ones(3))
+
+
+class TestRegressionPlotRSquared(unittest.TestCase):
+    """Issue 5: R^2 divided by zero when y is constant."""
+
+    def tearDown(self):
+        plt.close('all')
+
+    def test_constant_y_no_warning(self):
+        x = np.linspace(0, 10, 50)
+        y = np.full(50, 3.0)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', RuntimeWarning)
+            ax = regression_plot(x, y)
+        # The R^2 annotation must be finite (perfect fit on a flat line -> 1.0).
+        texts = [t.get_text() for t in ax.texts if 'R' in t.get_text()]
+        self.assertTrue(any('1.000' in t for t in texts))
+
+    def test_normal_regression_r2_reasonable(self):
+        x = np.linspace(0, 10, 100)
+        y = 2 * x + 1 + np.random.RandomState(0).randn(100) * 0.1
+        ax = regression_plot(x, y)
+        texts = [t.get_text() for t in ax.texts if 'R' in t.get_text()]
+        self.assertTrue(texts)
+
+
+class TestNeuralTrajectoryValidation(unittest.TestCase):
+    """Issue 6: cryptic IndexError for < 2 feature columns."""
+
+    def tearDown(self):
+        plt.close('all')
+
+    def test_single_feature_raises_valueerror(self):
+        with self.assertRaises(ValueError):
+            neural_trajectory(np.random.rand(100, 1))
+
+    def test_out_of_range_dims_raise(self):
+        with self.assertRaises(ValueError):
+            neural_trajectory(np.random.rand(100, 2), dims=(0, 5))
+
+    def test_non_2d_raises(self):
+        with self.assertRaises(ValueError):
+            neural_trajectory(np.random.rand(100))
+
+    def test_valid_2d_and_3d(self):
+        ax2 = neural_trajectory(np.random.rand(50, 2), time_color=False)
+        self.assertIsNotNone(ax2)
+        ax3 = neural_trajectory(np.random.rand(50, 3), time_color=False)
+        self.assertIsNotNone(ax3)
+
+
+class TestCorrelationMatrixSingleFeature(unittest.TestCase):
+    """Issue 7: single-feature input produced a 0-d scalar -> imshow crash."""
+
+    def tearDown(self):
+        plt.close('all')
+
+    def test_single_feature_pearson(self):
+        ax = correlation_matrix(np.random.rand(100, 1))
+        _draw(ax)
+        cm = ax.get_images()[0].get_array()
+        self.assertEqual(cm.shape, (1, 1))
+        self.assertAlmostEqual(float(cm[0, 0]), 1.0)
+
+    def test_single_feature_spearman(self):
+        ax = correlation_matrix(np.random.rand(100, 1), method='spearman')
+        _draw(ax)
+
+    def test_single_feature_kendall(self):
+        ax = correlation_matrix(np.random.rand(100, 1), method='kendall')
+        _draw(ax)
+
+    def test_1d_input_treated_as_single_feature(self):
+        ax = correlation_matrix(np.random.rand(100))
+        _draw(ax)
+        self.assertEqual(ax.get_images()[0].get_array().shape, (1, 1))
+
+
+class TestAnimate2DShapeHandling(unittest.TestCase):
+    """Issue 8: cryptic unpack error for non-2D input / size mismatch."""
+
+    def tearDown(self):
+        plt.close('all')
+
+    def test_2d_input(self):
+        anim = animate_2D(np.random.rand(10, 25), net_size=(5, 5), show=False)
+        self.assertIsNotNone(anim)
+
+    def test_3d_input_accepted(self):
+        anim = animate_2D(np.random.rand(10, 5, 5), net_size=(5, 5), show=False)
+        self.assertIsNotNone(anim)
+
+    def test_size_mismatch_raises(self):
+        with self.assertRaises(ValueError):
+            animate_2D(np.random.rand(10, 30), net_size=(5, 5), show=False)
+
+    def test_3d_frame_mismatch_raises(self):
+        with self.assertRaises(ValueError):
+            animate_2D(np.random.rand(10, 4, 4), net_size=(5, 5), show=False)
+
+    def test_bad_ndim_raises(self):
+        with self.assertRaises(ValueError):
+            animate_2D(np.random.rand(10), net_size=(5, 5), show=False)
+
+
+class TestRocCurveAUC(unittest.TestCase):
+    """Issue 9: AUC was not anchored at the curve endpoints."""
+
+    def tearDown(self):
+        plt.close('all')
+
+    @staticmethod
+    def _auc(ax):
+        for line in ax.get_lines():
+            lbl = line.get_label()
+            if 'AUC' in lbl:
+                return float(lbl.split('=')[1])
+        raise AssertionError('No AUC label found')
+
+    def test_perfect_classifier_auc_one(self):
+        y_true = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
+        y_scores = np.array([.1, .2, .3, .4, .45, .6, .7, .8, .9, .95])
+        ax = roc_curve(y_true, y_scores)
+        self.assertAlmostEqual(self._auc(ax), 1.0, places=3)
+
+    def test_auc_in_unit_interval(self):
+        rng = np.random.RandomState(0)
+        y_true = rng.randint(0, 2, 200)
+        y_scores = rng.rand(200)
+        ax = roc_curve(y_true, y_scores)
+        auc = self._auc(ax)
+        self.assertGreaterEqual(auc, 0.0)
+        self.assertLessEqual(auc, 1.0)
+
+    def test_curve_anchored_at_endpoints(self):
+        y_true = np.array([0, 1, 0, 1, 1, 0])
+        y_scores = np.array([.2, .8, .3, .7, .9, .1])
+        ax = roc_curve(y_true, y_scores)
+        line = ax.get_lines()[0]
+        xs, ys = line.get_xdata(), line.get_ydata()
+        self.assertAlmostEqual(xs[0], 0.0)
+        self.assertAlmostEqual(ys[0], 0.0)
+        self.assertAlmostEqual(xs[-1], 1.0)
+        self.assertAlmostEqual(ys[-1], 1.0)
+
+
+class TestBrainSurfaceNormalization(unittest.TestCase):
+    """Issue 10: signed values were mis-normalized (/max only)."""
+
+    def tearDown(self):
+        plt.close('all')
+
+    def test_signed_values_run(self):
+        verts = np.random.RandomState(0).randn(20, 3)
+        faces = np.random.RandomState(1).randint(0, 20, (10, 3))
+        vals = np.linspace(-5, 5, 20)
+        ax = brain_surface_3d(verts, faces, values=vals)
+        self.assertIsNotNone(ax)
+
+    def test_constant_values_no_nan(self):
+        verts = np.random.RandomState(0).randn(20, 3)
+        faces = np.random.RandomState(1).randint(0, 20, (10, 3))
+        vals = np.full(20, 2.0)
+        ax = brain_surface_3d(verts, faces, values=vals)
+        self.assertIsNotNone(ax)
+
+
+class TestVolumeRenderingCmap(unittest.TestCase):
+    """Issue 11: documented ``cmap`` parameter was ignored."""
+
+    def tearDown(self):
+        plt.close('all')
+
+    def test_cmap_applied(self):
+        vol = np.random.RandomState(0).rand(6, 6, 6)
+        ax = volume_rendering(vol, threshold=0.5, cmap='plasma')
+        self.assertIsNotNone(ax)
+
+    def test_empty_volume_no_crash(self):
+        vol = np.zeros((5, 5, 5))
+        ax = volume_rendering(vol, threshold=0.5)
+        self.assertIsNotNone(ax)
+
+
+class TestNeuralNetwork3DReturn(unittest.TestCase):
+    """Issue 12: doc example unpacked the single returned Axes."""
+
+    def tearDown(self):
+        plt.close('all')
+
+    def test_returns_single_axes(self):
+        from mpl_toolkits.mplot3d import Axes3D
+        ret = neural_network_3d([4, 3, 2])
+        self.assertIsInstance(ret, Axes3D)
+        with self.assertRaises(TypeError):
+            _a, _b = neural_network_3d([4, 3, 2])  # not unpackable
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/braintools/visualize/_interactive.py
+++ b/braintools/visualize/_interactive.py
@@ -676,10 +676,16 @@ def interactive_correlation_matrix(
     _check_plotly()
 
     data = as_numpy(data)
+    if data.ndim == 1:
+        data = data.reshape(-1, 1)
 
     # Calculate correlation matrix
-    if method == 'pearson':
-        corr_matrix = np.corrcoef(data.T)
+    if data.shape[1] == 1:
+        # A single feature has the trivial 1x1 correlation matrix; the methods
+        # below would return a 0-d scalar that breaks the heatmap.
+        corr_matrix = np.array([[1.0]])
+    elif method == 'pearson':
+        corr_matrix = np.atleast_2d(np.corrcoef(data.T))
     elif method == 'spearman':
         from scipy.stats import spearmanr
         # spearmanr returns a scalar for exactly two columns; build the 2x2
@@ -688,7 +694,7 @@ def interactive_correlation_matrix(
             rho = spearmanr(data[:, 0], data[:, 1])[0]
             corr_matrix = np.array([[1.0, rho], [rho, 1.0]])
         else:
-            corr_matrix = np.asarray(spearmanr(data)[0])
+            corr_matrix = np.atleast_2d(spearmanr(data)[0])
     else:
         raise ValueError(f"Unknown correlation method: {method}")
 

--- a/braintools/visualize/_neural.py
+++ b/braintools/visualize/_neural.py
@@ -116,21 +116,35 @@ def spike_raster(
     elif neuron_ids is None:
         raise ValueError("neuron_ids must be provided when spike_times is not a list")
 
+    # When ``color`` is a per-spike array it must be filtered with the same masks
+    # applied to the spikes; otherwise ``scatter`` raises a length-mismatch error
+    # ("'c' argument has N elements ... inconsistent with x and y").
+    color_arr = color
+    is_color_array = (
+        not isinstance(color, str)
+        and hasattr(color, '__len__')
+        and len(color) == len(spike_times)
+    )
+
     # Apply time filtering
     if time_range is not None:
         mask = (spike_times >= time_range[0]) & (spike_times <= time_range[1])
         spike_times = spike_times[mask]
         neuron_ids = neuron_ids[mask]
+        if is_color_array:
+            color_arr = np.asarray(color_arr)[mask]
 
     # Apply neuron filtering
     if neuron_range is not None:
         mask = (neuron_ids >= neuron_range[0]) & (neuron_ids <= neuron_range[1])
         spike_times = spike_times[mask]
         neuron_ids = neuron_ids[mask]
+        if is_color_array:
+            color_arr = np.asarray(color_arr)[mask]
 
     # Plot spikes
     if len(spike_times) > 0:
-        ax.scatter(spike_times, neuron_ids, c=color, marker=marker,
+        ax.scatter(spike_times, neuron_ids, c=color_arr, marker=marker,
                    s=markersize, alpha=alpha, **kwargs)
 
     # Labels and formatting
@@ -414,12 +428,30 @@ def neural_trajectory(
     """
     data = as_numpy(data)
 
+    if data.ndim != 2:
+        raise ValueError(
+            f"data must be 2D (time, features), got {data.ndim}D."
+        )
+    n_features = data.shape[1]
+
     # Determine dimensions
     if dims is None:
-        if data.shape[1] >= 3:
+        if n_features >= 3:
             dims = (0, 1, 2)
-        else:
+        elif n_features == 2:
             dims = (0, 1)
+        else:
+            raise ValueError(
+                "neural_trajectory needs at least 2 feature columns to plot a "
+                f"trajectory, but data has shape {data.shape}."
+            )
+    else:
+        invalid = [d for d in dims if d < 0 or d >= n_features]
+        if invalid:
+            raise ValueError(
+                f"dims {dims} reference columns outside data with {n_features} "
+                f"features (invalid: {invalid})."
+            )
 
     is_3d = len(dims) == 3
 

--- a/braintools/visualize/_plots.py
+++ b/braintools/visualize/_plots.py
@@ -135,10 +135,13 @@ def line_plot(
     if ax is None:
         ax = plt.gca()
 
-    val_matrix = val_matrix.reshape((val_matrix.shape[0], -1))
-    # change data
+    # Convert to arrays *before* reshaping. ``np.asarray`` stacks Python lists
+    # into an ndarray and triggers ``__array__`` for JAX / brainunit inputs;
+    # reshaping the raw input first used to crash with
+    # ``AttributeError: 'list' object has no attribute 'reshape'``.
     val_matrix = np.asarray(val_matrix)
     ts = np.asarray(ts)
+    val_matrix = val_matrix.reshape((val_matrix.shape[0], -1))
 
     # Validate dimensions
     if len(ts) != val_matrix.shape[0]:
@@ -379,10 +382,33 @@ def animate_2D(
     """
     dt = _resolve_dt(dt)
     values = np.asarray(values)
-    num_step, num_neuron = values.shape
     height, width = net_size
 
-    values = np.asarray(values).reshape((num_step, height, width))
+    # Accept either a flat ``(num_step, num_neuron)`` matrix or an already-shaped
+    # ``(num_step, height, width)`` array, validating the neuron count against
+    # ``net_size`` so a mismatch raises a clear error instead of an opaque
+    # reshape/unpack failure.
+    if values.ndim == 2:
+        num_step, num_neuron = values.shape
+        if num_neuron != height * width:
+            raise ValueError(
+                f"net_size {net_size} expects {height * width} neurons per step, "
+                f"but values has {num_neuron}."
+            )
+        values = values.reshape((num_step, height, width))
+    elif values.ndim == 3:
+        num_step = values.shape[0]
+        if values.shape[1:] != (height, width):
+            raise ValueError(
+                f"values has per-frame shape {values.shape[1:]}, which does not "
+                f"match net_size {net_size}."
+            )
+    else:
+        raise ValueError(
+            "values must be 2D (num_step, num_neuron) or 3D (num_step, height, "
+            f"width), got {values.ndim}D."
+        )
+
     val_min = values.min() if val_min is None else val_min
     val_max = values.max() if val_max is None else val_max
 
@@ -501,49 +527,45 @@ def animate_1D(
     gs = GridSpec(1, 1, figure=fig)
     fig.add_subplot(gs[0, 0])
 
-    # check dynamical variables
+    # check dynamical variables -- normalize every entry to a *fresh*
+    # {'xs', 'ys', 'legend'} dict so the caller's input dictionaries are never
+    # mutated in place (previously the function added 'xs'/'legend' keys and
+    # overwrote 'ys' on the user's objects).
     final_dynamic_vars = []
     lengths = []
     has_legend = False
+
+    def _normalize_dynamic(var):
+        nonlocal has_legend
+        if isinstance(var, dict):
+            assert 'ys' in var, 'Must provide "ys" item.'
+            ys = np.asarray(var['ys'])
+            legend = var.get('legend', None)
+            if 'legend' in var:
+                has_legend = True
+            xs = np.asarray(var['xs']) if 'xs' in var else None
+        elif isinstance(var, (np.ndarray, brainstate.State)):
+            ys = np.asarray(var)
+            legend = None
+            xs = None
+        else:
+            raise ValueError(f'Unknown data type: {type(var)}')
+        assert np.ndim(ys) == 2, "Dynamic variable must be 2D data."
+        if xs is None:
+            xs = np.arange(ys.shape[1])
+        return {'xs': xs, 'ys': ys, 'legend': legend}
+
     if isinstance(dynamical_vars, (tuple, list)):
         for var in dynamical_vars:
-            if isinstance(var, dict):
-                assert 'ys' in var, 'Must provide "ys" item.'
-                if 'legend' not in var:
-                    var['legend'] = None
-                else:
-                    has_legend = True
-                var['ys'] = np.asarray(var['ys'])
-                if 'xs' not in var:
-                    var['xs'] = np.arange(var['ys'].shape[1])
-            elif isinstance(var, (np.ndarray, brainstate.State)):
-                var = np.asarray(var)
-                var = {'ys': var,
-                       'xs': np.arange(var.shape[1]),
-                       'legend': None}
-            else:
-                raise ValueError(f'Unknown data type: {type(var)}')
-            assert np.ndim(var['ys']) == 2, "Dynamic variable must be 2D data."
-            lengths.append(var['ys'].shape[0])
-            final_dynamic_vars.append(var)
-    elif isinstance(dynamical_vars, dict):
-        assert 'ys' in dynamical_vars, 'Must provide "ys" item.'
-        if 'legend' not in dynamical_vars:
-            dynamical_vars['legend'] = None
-        else:
-            has_legend = True
-        dynamical_vars['ys'] = np.asarray(dynamical_vars['ys'])
-        if 'xs' not in dynamical_vars:
-            dynamical_vars['xs'] = np.arange(dynamical_vars['ys'].shape[1])
-        lengths.append(dynamical_vars['ys'].shape[0])
-        final_dynamic_vars.append(dynamical_vars)
+            norm = _normalize_dynamic(var)
+            lengths.append(norm['ys'].shape[0])
+            final_dynamic_vars.append(norm)
+    elif isinstance(dynamical_vars, (dict, np.ndarray, brainstate.State)):
+        norm = _normalize_dynamic(dynamical_vars)
+        lengths.append(norm['ys'].shape[0])
+        final_dynamic_vars.append(norm)
     else:
-        assert np.ndim(dynamical_vars) == 2, "Dynamic variable must be 2D data."
-        dynamical_vars = np.asarray(dynamical_vars)
-        lengths.append(dynamical_vars.shape[0])
-        final_dynamic_vars.append({'ys': dynamical_vars,
-                                   'xs': np.arange(dynamical_vars.shape[1]),
-                                   'legend': None})
+        raise ValueError(f'Unknown data type: {type(dynamical_vars)}')
     lengths = np.array(lengths)
     assert np.all(lengths == lengths[0]), 'Dynamic variables must have equal length.'
 

--- a/braintools/visualize/_statistical.py
+++ b/braintools/visualize/_statistical.py
@@ -98,10 +98,17 @@ def correlation_matrix(
         fig, ax = plt.subplots(figsize=figsize)
 
     data = as_numpy(data)
+    if data.ndim == 1:
+        data = data.reshape(-1, 1)
 
     # Calculate correlation matrix
-    if method == 'pearson':
-        corr_matrix = np.corrcoef(data.T)
+    if data.shape[1] == 1:
+        # A single feature has the trivial 1x1 correlation matrix; the methods
+        # below would return a 0-d scalar that breaks ``imshow``.
+        corr_matrix = np.array([[1.0]])
+    elif method == 'pearson':
+        # ``np.atleast_2d`` keeps a 2-D result even for degenerate inputs.
+        corr_matrix = np.atleast_2d(np.corrcoef(data.T))
     elif method == 'spearman':
         # ``spearmanr`` returns a scalar (not a 2x2 matrix) when ``data`` has
         # exactly two columns, which then breaks ``imshow``. Build the matrix
@@ -110,7 +117,7 @@ def correlation_matrix(
             rho = stats.spearmanr(data[:, 0], data[:, 1])[0]
             corr_matrix = np.array([[1.0, rho], [rho, 1.0]])
         else:
-            corr_matrix = np.asarray(stats.spearmanr(data)[0])
+            corr_matrix = np.atleast_2d(stats.spearmanr(data)[0])
     elif method == 'kendall':
         # ``kendalltau`` only compares two 1-D samples, so build the
         # feature-by-feature matrix pairwise.
@@ -672,11 +679,16 @@ def regression_plot(
 
         ax.plot(x_fit, y_fit, color='red', linewidth=2, label='Fit')
 
-        # Calculate R-squared
+        # Calculate R-squared. Guard against a constant ``y`` (ss_tot == 0),
+        # which would otherwise divide by zero and yield NaN: a perfect fit
+        # (ss_res == 0) is R² = 1.0, anything else is undefined -> 0.0.
         y_pred = np.polyval(coeffs, x)
         ss_res = np.sum((y - y_pred) ** 2)
         ss_tot = np.sum((y - np.mean(y)) ** 2)
-        r_squared = 1 - (ss_res / ss_tot)
+        if ss_tot == 0:
+            r_squared = 1.0 if np.isclose(ss_res, 0.0) else 0.0
+        else:
+            r_squared = 1 - (ss_res / ss_tot)
 
         # Add R-squared to plot
         ax.text(0.05, 0.95, f'R² = {r_squared:.3f}', transform=ax.transAxes,
@@ -828,13 +840,23 @@ def confusion_matrix(
         for j, pred_class in enumerate(classes):
             cm[i, j] = np.sum((y_true == true_class) & (y_pred == pred_class))
 
-    # Normalize if requested
+    # Normalize if requested. Guard against empty rows/columns (a class that
+    # never appears in y_true / y_pred) so the division yields 0 instead of NaN.
+    def _safe_divide(numerator, denominator):
+        denominator = np.asarray(denominator, dtype=float)
+        return np.divide(
+            numerator, denominator,
+            out=np.zeros_like(cm, dtype=float),
+            where=denominator != 0,
+        )
+
     if normalize == 'true':
-        cm = cm / cm.sum(axis=1, keepdims=True)
+        cm = _safe_divide(cm, cm.sum(axis=1, keepdims=True))
     elif normalize == 'pred':
-        cm = cm / cm.sum(axis=0, keepdims=True)
+        cm = _safe_divide(cm, cm.sum(axis=0, keepdims=True))
     elif normalize == 'all':
-        cm = cm / cm.sum()
+        total = cm.sum()
+        cm = cm / total if total != 0 else cm
 
     # Plot matrix
     im = ax.imshow(cm, cmap=cmap, **kwargs)
@@ -926,11 +948,17 @@ def roc_curve(
         tpr.append(tp / (tp + fn) if (tp + fn) > 0 else 0)
         fpr.append(fp / (fp + tn) if (fp + tn) > 0 else 0)
 
-    tpr = np.array(tpr)
-    fpr = np.array(fpr)
+    # Anchor the curve at (0, 0) and (1, 1) so the AUC is not underestimated
+    # when several samples tie at the most/least confident score. Sorting by
+    # FPR keeps the trapezoidal integration monotonic.
+    fpr = np.concatenate([[0.0], np.array(fpr), [1.0]])
+    tpr = np.concatenate([[0.0], np.array(tpr), [1.0]])
+    order = np.argsort(fpr, kind='stable')
+    fpr = fpr[order]
+    tpr = tpr[order]
 
-    # Calculate AUC
-    auc = _trapezoid(tpr, fpr)
+    # Calculate AUC (clamped to [0, 1] to absorb floating-point error).
+    auc = float(np.clip(_trapezoid(tpr, fpr), 0.0, 1.0))
 
     # Plot ROC curve
     ax.plot(fpr, tpr, color=color, linewidth=2, label=f'AUC = {auc:.3f}', **kwargs)

--- a/braintools/visualize/_three_d.py
+++ b/braintools/visualize/_three_d.py
@@ -207,10 +207,14 @@ def brain_surface_3d(
         values = as_numpy(values)
         # Average values for each face
         face_values = np.mean(values[faces], axis=1)
-        # Normalize to [0, 1] for the colormap, guarding against an all-zero
-        # (degenerate) range that would produce NaN colors.
+        # Min-max normalize to [0, 1] for the colormap so signed values map
+        # correctly (dividing by ``max`` alone pushed negatives outside [0, 1],
+        # where the colormap clamps them). Guard against a degenerate (constant)
+        # range that would produce NaN colors.
+        min_val = np.min(face_values)
         max_val = np.max(face_values)
-        scaled = face_values / max_val if max_val != 0 else np.zeros_like(face_values)
+        span = max_val - min_val
+        scaled = (face_values - min_val) / span if span != 0 else np.zeros_like(face_values)
         # ``plt.cm.get_cmap`` was deprecated in matplotlib 3.7 and is removed in
         # 3.11; use the colormap registry instead.
         cmap_obj = plt.get_cmap(cmap) if isinstance(cmap, str) else cmap
@@ -471,8 +475,20 @@ def volume_rendering(
     # Create binary mask
     binary_volume = volume > threshold
 
+    # Color the filled voxels by their normalized intensity using ``cmap``
+    # (previously ``cmap`` was documented but never applied).
+    cmap_obj = plt.get_cmap(cmap) if isinstance(cmap, str) else cmap
+    voxel_kwargs = dict(kwargs)
+    if 'facecolors' not in voxel_kwargs and bool(binary_volume.any()):
+        filled = volume[binary_volume]
+        vmin = float(filled.min())
+        vmax = float(filled.max())
+        span = vmax - vmin
+        norm_vol = (volume - vmin) / span if span != 0 else np.zeros_like(volume, dtype=float)
+        voxel_kwargs['facecolors'] = cmap_obj(np.clip(norm_vol, 0.0, 1.0))
+
     # Plot voxels
-    ax.voxels(binary_volume, alpha=alpha, **kwargs)
+    ax.voxels(binary_volume, alpha=alpha, **voxel_kwargs)
 
     # Labels
     ax.set_xlabel('X')

--- a/docs/braintools-visualize-issues-found-20260619.md
+++ b/docs/braintools-visualize-issues-found-20260619.md
@@ -1,0 +1,205 @@
+# braintools.visualize — Issues Found (2026-06-19)
+
+Audit of `braintools/visualize/` and its documentation, performed as a senior
+Python/JAX reviewer. Each issue below was reproduced before being recorded.
+Severity legend: **High** (crash / wrong result in documented usage),
+**Medium** (crash / wrong result on a reasonable edge case), **Low** (quality /
+documentation).
+
+Environment: numpy 2.4.6, matplotlib 3.10.8, scipy 1.17.1, plotly absent.
+
+---
+
+## 1. `line_plot` reshapes before converting to an array — crashes on list input
+**File:** `_plots.py` · **Severity:** High
+
+```python
+val_matrix = val_matrix.reshape((val_matrix.shape[0], -1))  # line 138
+val_matrix = np.asarray(val_matrix)                          # line 140
+```
+
+`reshape` is called on the raw `val_matrix` *before* it is converted with
+`np.asarray`. The empty-check on line 121 (`len(val_matrix) == 0`) accepts Python
+lists, so a list reaches line 138 and raises
+`AttributeError: 'list' object has no attribute 'reshape'`. The same ordering
+also strips `brainunit` units silently for Quantity input.
+
+**Repro**
+```python
+line_plot(list(range(5)), [[1],[2],[3],[4],[5]], plot_ids=[0])
+# AttributeError: 'list' object has no attribute 'reshape'
+```
+
+**Proposed fix:** Convert with `np.asarray` (stacks lists into an ndarray and
+triggers `__array__` for JAX / brainunit) *before* reshaping. Note: `as_numpy`
+is unsuitable here because it tree-maps and would leave a nested list a list.
+
+---
+
+## 2. `spike_raster` does not filter a per-spike `color` array — crashes with `time_range`/`neuron_range`
+**File:** `_neural.py` · **Severity:** High
+
+When `color` is an array of per-spike colors and a `time_range` or `neuron_range`
+filter is applied, `spike_times`/`neuron_ids` are masked but `color` is not, so
+`ax.scatter(..., c=color)` raises a length-mismatch error.
+
+**Repro**
+```python
+st = np.linspace(0, 100, 50); nid = np.arange(50) % 10
+spike_raster(st, nid, color=np.random.rand(50), time_range=(0, 50))
+# ValueError: 'c' argument has 50 elements, inconsistent with x/y of size 25
+```
+
+**Proposed fix:** When `color` is array-like with length equal to the number of
+spikes, apply the same mask(s) used on `spike_times`/`neuron_ids`.
+
+---
+
+## 3. `animate_1D` mutates the caller's input dictionaries
+**File:** `_plots.py` · **Severity:** Medium
+
+For dict / list-of-dict input, the function writes `var['legend']`, `var['xs']`
+and overwrites `var['ys']` on the *caller's* objects, e.g.:
+
+```python
+d = {'ys': arr}
+animate_1D(d, show=False)
+# d now also contains 'xs' and 'legend'
+```
+
+**Proposed fix:** Build fresh dictionaries rather than mutating inputs.
+
+---
+
+## 4. `confusion_matrix` normalization divides by zero → NaN
+**File:** `_statistical.py` · **Severity:** Medium
+
+```python
+cm = cm / cm.sum(axis=0, keepdims=True)   # 'pred'
+```
+
+When a class never appears in `y_pred` (column sum 0) — or `y_true` for `'true'` —
+the division yields `NaN` and emits a RuntimeWarning, producing blank/incorrect
+cells.
+
+**Repro**
+```python
+confusion_matrix([0,1,2,2,1,0], [0,1,1,1,1,0], normalize='pred')  # class 2 never predicted
+# RuntimeWarning: invalid value encountered in divide
+```
+
+**Proposed fix:** Divide with a guarded denominator (treat 0 as 0 instead of NaN).
+
+---
+
+## 5. `regression_plot` R² divides by zero for constant `y`
+**File:** `_statistical.py` · **Severity:** Medium
+
+```python
+ss_tot = np.sum((y - np.mean(y)) ** 2)   # == 0 when y is constant
+r_squared = 1 - (ss_res / ss_tot)        # 1 - 0/0 -> NaN + warning
+```
+
+**Proposed fix:** Guard `ss_tot == 0` (define R² as 1.0 when the fit is perfect,
+else 0.0) and avoid the warning.
+
+---
+
+## 6. `neural_trajectory` raises a cryptic `IndexError` for < 2 features
+**File:** `_neural.py` · **Severity:** Medium
+
+With `data` of shape `(T, 1)`, `dims` defaults to `(0, 1)` and `data[:, 1]` raises
+`IndexError: index 1 is out of bounds`.
+
+**Proposed fix:** Validate that the data has at least 2 columns (or that the
+requested `dims` are in range) and raise a clear `ValueError`.
+
+---
+
+## 7. `correlation_matrix` / `interactive_correlation_matrix` crash on a single feature
+**File:** `_statistical.py`, `_interactive.py` · **Severity:** Medium
+
+`np.corrcoef(data.T)` on a single-column input returns a 0-d scalar, so
+`imshow` raises `TypeError: Invalid shape () for image data`.
+
+**Proposed fix:** Coerce the correlation result to at least a 2-D array; a single
+feature yields the trivial `[[1.0]]` matrix.
+
+---
+
+## 8. `animate_2D` gives a cryptic error for non-2D input / size mismatch
+**File:** `_plots.py` · **Severity:** Low/Medium
+
+`num_step, num_neuron = values.shape` raises *"too many values to unpack"* when
+`values` is already `(T, H, W)`, and a mismatched `net_size` produces an opaque
+reshape error.
+
+**Proposed fix:** Accept either `(T, N)` or `(T, H, W)` input and validate
+`N == H*W` with a clear `ValueError`.
+
+---
+
+## 9. `roc_curve` / `precision_recall_curve` AUC not anchored at the curve endpoints
+**File:** `_statistical.py` · **Severity:** Low
+
+The AUC/AP trapezoid integrates only over the observed thresholds; the ROC curve
+is not anchored at `(0,0)`/`(1,1)`, so when several samples tie at the top score
+the leading area is dropped and AUC is underestimated.
+
+**Proposed fix:** Prepend `(fpr=0, tpr=0)` and append `(fpr=1, tpr=1)` for ROC
+before integrating; keep the result clamped to `[0, 1]`.
+
+---
+
+## 10. `brain_surface_3d` mis-colors signed data (normalization bug)
+**File:** `_three_d.py` · **Severity:** Low/Medium
+
+```python
+scaled = face_values / max_val      # only divides by max
+```
+
+For signed `values`, negatives map to `< 0` (outside the colormap's `[0, 1]`
+domain) and get clamped, so the surface coloring is wrong.
+
+**Proposed fix:** Use min–max normalization `(v - vmin) / (vmax - vmin)` with a
+guard for a degenerate (constant) range.
+
+---
+
+## 11. `volume_rendering` ignores its documented `cmap` parameter
+**File:** `_three_d.py` · **Severity:** Low
+
+`cmap` is documented and accepted but never applied — `ax.voxels` is called
+without face colors, so the rendering is always the matplotlib default.
+
+**Proposed fix:** Map the thresholded volume intensities through `cmap` and pass
+the resulting `facecolors` to `voxels`.
+
+---
+
+## 12. Documentation: `fig, ax = neural_network_3d(...)` cannot be unpacked
+**File:** `visualize/__init__.py` (module docstring) · **Severity:** Low
+
+`neural_network_3d` returns a single `Axes3D`, but the "Quick Start - Neural
+Network 3D" example unpacks it as `fig, ax = neural_network_3d(...)`, which raises
+`TypeError: cannot unpack non-iterable Axes3D object` if copy-pasted.
+
+**Proposed fix:** Change the example to `ax = neural_network_3d(...)`.
+
+---
+
+## Non-issues / verified correct
+- `as_numpy` uses `jax.tree.map`, so Python lists remain lists — the
+  list-of-arrays branches in `spike_raster`, `spike_histogram`, `isi_distribution`,
+  `interactive_spike_raster`, and `dashboard_neural_activity` work as intended.
+- `_trapezoid = getattr(np, 'trapezoid', None) or np.trapz` correctly handles the
+  NumPy 2.x rename/removal of `np.trapz`.
+- `apply_style` context-manager rcParams restore and `create_neural_colormap`
+  `force=True` re-registration are correct.
+- `firing_rate_map` rectangular-grid binning is correct (rows index y, cols x).
+- `connectivity_matrix` with all-zero weights handles the degenerate `Normalize`.
+
+## Test plan
+A dedicated regression module (`_audit_20260619_test.py`) adds one test per issue
+above, run under the Agg backend, alongside the existing suite (231 passed /
+31 plotly-skipped at baseline).


### PR DESCRIPTION
## Summary

Senior Python/JAX review of `braintools/visualize/` and its documentation. Full writeup with reproductions and proposed solutions in `docs/braintools-visualize-issues-found-20260619.md`.

## Bugs fixed

| # | Function | Issue |
|---|----------|-------|
| 1 | `line_plot` | Reshaped before converting → crashed on list / non-ndarray input |
| 2 | `spike_raster` | Per-spike `color` array not filtered with `time_range`/`neuron_range` → scatter length mismatch |
| 3 | `animate_1D` | Mutated the caller's input dict(s) in place |
| 4 | `confusion_matrix` | Normalization divided by zero → NaN cells + RuntimeWarning |
| 5 | `regression_plot` | R² divided by zero for constant `y` |
| 6 | `neural_trajectory` | Cryptic `IndexError` for <2 feature columns |
| 7 | `correlation_matrix` / `interactive_correlation_matrix` | Single-feature input crashed imshow/heatmap |
| 8 | `animate_2D` | Opaque unpack/reshape error for non-2D input / size mismatch |
| 9 | `roc_curve` | AUC not anchored at curve endpoints (could underestimate) |
| 10 | `brain_surface_3d` | Signed face values mis-normalized (`/max` only) → wrong colors |
| 11 | `volume_rendering` | Documented `cmap` parameter ignored |
| 12 | docs (`__init__`) | `fig, ax = neural_network_3d(...)` — returns a single `Axes` |

## Tests

- New `braintools/visualize/_audit_20260619_test.py` — 38 regression tests, one (or more) per issue.
- Full suite: **269 passed, 31 skipped** (plotly-gated).
- Coverage of exercised source modules: **99%** (`_plots`/`_neural`/`_three_d` at 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)