### PR TITLE
fix(trainer): LR-monitor logging, save_top_k pruning, resume, distributed collectives

### DIFF
--- a/braintools/trainer/_audit_20260619_test.py
+++ b/braintools/trainer/_audit_20260619_test.py
@@ -1,0 +1,275 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Regression tests for the 2026-06-19 ``braintools.trainer`` audit.
+
+Each test reproduces a specific issue documented in
+``docs/braintools-trainer-issues-found-20260619.md`` (T-A .. T-H).
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import brainstate
+import braintools
+from braintools.trainer import (
+    Trainer,
+    LightningModule,
+    DataLoader,
+    Logger,
+    LearningRateMonitor,
+    ModelCheckpoint,
+    CheckpointManager,
+)
+
+
+class _Net(LightningModule):
+    def __init__(self):
+        super().__init__()
+        self.l = brainstate.nn.Linear(4, 2)
+
+    def __call__(self, x):
+        return self.l(x)
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        loss = jnp.mean((self(x) - y) ** 2)
+        self.log('train_loss', loss, prog_bar=True)
+        return {'loss': loss}
+
+    def validation_step(self, batch, batch_idx):
+        x, y = batch
+        loss = jnp.mean((self(x) - y) ** 2)
+        self.log('val_loss', loss)
+        return {'val_loss': loss}
+
+    def configure_optimizers(self):
+        return braintools.optim.Adam(lr=1e-3)
+
+
+def _loader(n=16, bs=4):
+    x = jnp.asarray(np.random.randn(n, 4).astype('float32'))
+    y = jnp.asarray(np.random.randn(n, 2).astype('float32'))
+    return DataLoader((x, y), batch_size=bs)
+
+
+class _SpyLogger(Logger):
+    """Records every metrics dict passed to ``log_metrics``."""
+
+    def __init__(self):
+        super().__init__()
+        self.captured = []
+
+    def log_metrics(self, metrics, step=None):
+        self.captured.append(dict(metrics))
+
+    def log_hyperparams(self, params):
+        pass
+
+    @property
+    def keys(self):
+        out = set()
+        for c in self.captured:
+            out.update(c.keys())
+        return out
+
+
+# ---------------------------------------------------------------------------
+# T-A: metrics logged from callbacks/hooks must reach the loggers
+# ---------------------------------------------------------------------------
+
+class TestCallbackLoggedMetricsReachLogger:
+    def test_lr_monitor_step_mode_reaches_logger(self):
+        spy = _SpyLogger()
+        lrm = LearningRateMonitor(logging_interval='step')
+        trainer = Trainer(
+            max_epochs=1, logger=spy, enable_progress_bar=False,
+            enable_checkpointing=False, callbacks=[lrm],
+        )
+        trainer.fit(_Net(), _loader())
+        assert 'lr-opt0' in spy.keys, (
+            f"LR not propagated to logger; saw {sorted(spy.keys)}"
+        )
+        # And the value is the configured LR.
+        lr_vals = [c['lr-opt0'] for c in spy.captured if 'lr-opt0' in c]
+        assert lr_vals and lr_vals[0] == pytest.approx(1e-3)
+
+    def test_lr_monitor_epoch_mode_reaches_logger(self):
+        spy = _SpyLogger()
+        lrm = LearningRateMonitor(logging_interval='epoch')
+        trainer = Trainer(
+            max_epochs=2, logger=spy, enable_progress_bar=False,
+            enable_checkpointing=False, callbacks=[lrm],
+        )
+        trainer.fit(_Net(), _loader())
+        assert 'lr-opt0' in spy.keys, (
+            f"epoch-mode LR not propagated; saw {sorted(spy.keys)}"
+        )
+
+    def test_training_step_metrics_still_present(self):
+        # Guard against regression: training_step metrics must survive the merge.
+        spy = _SpyLogger()
+        trainer = Trainer(
+            max_epochs=1, logger=spy, enable_progress_bar=False,
+            enable_checkpointing=False,
+        )
+        trainer.fit(_Net(), _loader())
+        assert 'train_loss' in spy.keys
+
+
+# ---------------------------------------------------------------------------
+# T-B: ModelCheckpoint must not leave more than save_top_k files on disk
+# ---------------------------------------------------------------------------
+
+class TestModelCheckpointTopK:
+    def test_save_top_k_enforced_on_disk(self):
+        with tempfile.TemporaryDirectory() as d:
+            class _Worsening(_Net):
+                def validation_step(self, batch, batch_idx):
+                    # val_loss strictly increases with epoch -> later epochs worse.
+                    loss = jnp.asarray(float(self.current_epoch + 1))
+                    self.log('val_loss', loss)
+                    return {'val_loss': loss}
+
+            mc = ModelCheckpoint(
+                dirpath=d, monitor='val_loss', mode='min', save_top_k=2,
+                save_last=False, filename='ck-{epoch:02d}',
+            )
+            trainer = Trainer(
+                max_epochs=6, logger=False, enable_progress_bar=False,
+                enable_checkpointing=False, callbacks=[mc],
+                check_val_every_n_epoch=1,
+            )
+            trainer.fit(_Worsening(), _loader(), _loader())
+
+            files = sorted(f for f in os.listdir(d) if f.endswith('.ckpt'))
+            assert len(files) == 2, f"save_top_k=2 but found {files}"
+            # The two best (lowest val_loss) are epochs 0 and 1.
+            assert files == ['ck-00.ckpt', 'ck-01.ckpt']
+            assert len(mc.best_k_models) == 2
+
+
+# ---------------------------------------------------------------------------
+# T-C: resuming from a checkpoint whose step is None must not crash
+# ---------------------------------------------------------------------------
+
+class TestResumeStepNone:
+    def test_resume_with_step_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            cm = CheckpointManager(d, verbose=False)
+            path = cm.save(_Net(), epoch=0, step=None, metrics={'val_loss': 0.5})
+
+            trainer = Trainer(
+                max_epochs=1, logger=False, enable_progress_bar=False,
+                enable_checkpointing=False,
+            )
+            # Must not raise; global_step coerced to an int.
+            trainer.fit(_Net(), _loader(), ckpt_path=path)
+            assert isinstance(trainer.global_step, int)
+            assert trainer.global_step >= 0
+
+
+# ---------------------------------------------------------------------------
+# T-D / T-H: distributed collectives on multiple (fake CPU) devices.
+# Run in a subprocess so XLA can be configured with >1 host device before
+# JAX initialises in this process.
+# ---------------------------------------------------------------------------
+
+def _run_multidevice(snippet: str, n_devices: int = 4):
+    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    env = dict(os.environ)
+    env['XLA_FLAGS'] = f"--xla_force_host_platform_device_count={n_devices}"
+    env['JAX_PLATFORMS'] = 'cpu'
+    env['PYTHONPATH'] = repo_root + os.pathsep + env.get('PYTHONPATH', '')
+    proc = subprocess.run(
+        [sys.executable, '-c', textwrap.dedent(snippet)],
+        capture_output=True, text=True, env=env, timeout=300,
+    )
+    return proc
+
+
+class TestDistributedCollectivesMultiDevice:
+    def test_broadcast_valid_on_multiple_devices(self):
+        snippet = """
+            import jax, jax.numpy as jnp
+            from braintools.trainer import broadcast
+            assert jax.device_count() >= 2, jax.device_count()
+            x = jnp.arange(jax.device_count() * 1.0)
+            g = jax.pmap(lambda v: broadcast(v, src=0, axis_name='batch'), axis_name='batch')
+            out = g(x)
+            # Every replica must hold device 0's value (x[0] == 0.0).
+            assert jnp.allclose(out, x[0]), out
+            print('BROADCAST_OK')
+        """
+        proc = _run_multidevice(snippet)
+        assert 'BROADCAST_OK' in proc.stdout, (
+            f"stdout={proc.stdout!r}\nstderr={proc.stderr[-2000:]!r}"
+        )
+
+    def test_sync_batch_norm_matches_global_stats(self):
+        snippet = """
+            import jax, jax.numpy as jnp
+            from braintools.trainer._distributed import sync_batch_norm
+            nd = jax.device_count()
+            assert nd >= 2, nd
+            # Per-device data with DIFFERENT means so pooled var != mean of vars.
+            data = jnp.stack([jnp.arange(4.0) + 10.0 * i for i in range(nd)])  # (nd, 4)
+            mean, var = jax.pmap(lambda x: sync_batch_norm(x, axis_name='batch'),
+                                 axis_name='batch')(data)
+            flat = data.reshape(-1)
+            exp_mean = jnp.mean(flat)
+            exp_var = jnp.var(flat)
+            assert jnp.allclose(mean[0], exp_mean, atol=1e-4), (mean[0], exp_mean)
+            assert jnp.allclose(var[0], exp_var, atol=1e-4), (var[0], exp_var)
+            print('SBN_OK')
+        """
+        proc = _run_multidevice(snippet)
+        assert 'SBN_OK' in proc.stdout, (
+            f"stdout={proc.stdout!r}\nstderr={proc.stderr[-2000:]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T-G: FSDP auto-mesh must give the model axis a real size when devices allow.
+# ---------------------------------------------------------------------------
+
+class TestFSDPMeshBalancing:
+    def test_model_axis_gets_real_size(self):
+        snippet = """
+            import jax
+            from braintools.trainer import FullyShardedDataParallelStrategy
+            assert jax.device_count() == 4, jax.device_count()
+            s = FullyShardedDataParallelStrategy(data_axis='data', model_axis='model')
+            shape = s.mesh.shape
+            # 4 devices -> a balanced 2x2 mesh; model axis must be > 1.
+            assert shape['model'] > 1, shape
+            assert shape['data'] * shape['model'] == 4, shape
+            print('FSDP_OK')
+        """
+        proc = _run_multidevice(snippet, n_devices=4)
+        assert 'FSDP_OK' in proc.stdout, (
+            f"stdout={proc.stdout!r}\nstderr={proc.stderr[-2000:]!r}"
+        )
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/braintools/trainer/_callbacks.py
+++ b/braintools/trainer/_callbacks.py
@@ -631,8 +631,13 @@ class ModelCheckpoint(Callback):
             if self.best_score is None or self._is_better(current_score, self.best_score):
                 self.best_score = current_score
                 self.best_model_path = filepath
-            self._update_best_k(current_score, filepath)
+            # Save first, then prune. ``_update_best_k`` may evict this very file
+            # when it is the worst of the tracked set, and the eviction's
+            # ``_remove_checkpoint`` can only delete it once it exists on disk.
+            # Doing it in the other order left orphaned files that violated
+            # ``save_top_k``. (T-B)
             self._save_checkpoint(trainer, module, filepath)
+            self._update_best_k(current_score, filepath)
             self._last_saved_epoch = epoch
         elif self.save_top_k == -1 or self.save_top_k > 0:
             # No metric to monitor, just save
@@ -864,7 +869,8 @@ class LearningRateMonitor(Callback):
     logging_interval : str, default='step'
         When to log the learning rate. One of 'step' or 'epoch'.
     log_momentum : bool, default=False
-        Whether to also log momentum values.
+        Reserved for logging optimizer momentum values. Not yet implemented;
+        the value is accepted but currently has no effect.
 
     Examples
     --------
@@ -953,24 +959,40 @@ class LearningRateMonitor(Callback):
 
 class GradientClipCallback(Callback):
     """
-    Clip gradients during training.
+    Placeholder callback for gradient clipping configuration.
 
-    Note: This is usually handled by the Trainer's gradient_clip_val parameter,
-    but this callback provides more control and logging.
+    .. warning::
+
+       This callback does **not** itself clip gradients or log gradient norms.
+       Gradient clipping is performed inside the Trainer's JIT-compiled apply
+       step (where a Python callback cannot intercept the traced gradients), so
+       a callback hook cannot see or modify them. To clip gradients, configure
+       the Trainer directly::
+
+           Trainer(gradient_clip_val=1.0, gradient_clip_algorithm='norm')
+
+       The parameters below are validated and stored for forward compatibility
+       but currently have no runtime effect.
 
     Parameters
     ----------
     clip_val : float, optional
-        Maximum gradient norm or value.
+        Maximum gradient norm or value. Stored only; not applied.
     clip_algorithm : str, default='norm'
         Clipping algorithm. One of 'norm' (global norm) or 'value' (element-wise).
+        Validated only; not applied.
     log_grad_norm : bool, default=False
-        Whether to log the gradient norm before clipping.
+        Reserved for gradient-norm logging, which is not yet implemented.
+
+    See Also
+    --------
+    Trainer : Set ``gradient_clip_val`` / ``gradient_clip_algorithm`` there to
+        actually clip gradients.
 
     Examples
     --------
-    >>> grad_clip = GradientClipCallback(clip_val=1.0, log_grad_norm=True)
-    >>> trainer = Trainer(callbacks=[grad_clip])
+    >>> # Real clipping is configured on the Trainer, not via this callback:
+    >>> trainer = Trainer(gradient_clip_val=1.0, gradient_clip_algorithm='norm')
     """
     __module__ = 'braintools.trainer'
 

--- a/braintools/trainer/_dataloader.py
+++ b/braintools/trainer/_dataloader.py
@@ -741,6 +741,13 @@ def create_distributed_batches(
     Any
         Batches with shape (num_devices, batch_size, ...).
 
+    Notes
+    -----
+    Only full blocks of ``num_devices * batch_size`` samples are yielded; any
+    trailing samples that cannot fill a complete block are dropped (this keeps
+    the leading device axis a fixed size for ``pmap``). Size the data or
+    ``batch_size`` accordingly if you cannot afford to drop the remainder.
+
     Examples
     --------
     >>> for batch in create_distributed_batches(X, batch_size=32):

--- a/braintools/trainer/_distributed.py
+++ b/braintools/trainer/_distributed.py
@@ -360,12 +360,14 @@ class DataParallelStrategy(Strategy):
             raise ValueError(f"Unknown reduction operation: {op}")
 
     def broadcast(self, tensor: Any, src: int = 0) -> Any:
-        """Broadcast tensor from source device."""
-        return lax.ppermute(
-            tensor,
-            axis_name=self._axis_name,
-            perm=[(src, i) for i in range(self.num_devices)]
-        )
+        """Broadcast tensor from the source replica to all replicas.
+
+        Implemented via ``all_gather`` + index rather than ``ppermute``: a
+        broadcast is one-source-to-many-destinations, which ``ppermute`` cannot
+        express (it requires unique sources and destinations). (T-D)
+        """
+        gathered = lax.all_gather(tensor, self._axis_name)
+        return jax.tree.map(lambda g: g[src], gathered)
 
 
 class ShardedDataParallelStrategy(Strategy):
@@ -510,18 +512,20 @@ class FullyShardedDataParallelStrategy(Strategy):
             # requires a NumPy array. (T-15)
             devices = np.asarray(jax.devices())
             if model_axis:
-                # 2D mesh for data + model parallelism
-                n_devices = devices.size
-                # Try to create a balanced mesh
-                for dp in [n_devices, n_devices // 2, n_devices // 4]:
-                    if dp < 1:
-                        continue
-                    mp = n_devices // dp
-                    if dp * mp == n_devices:
+                # 2D mesh for data + model parallelism. Pick the most balanced
+                # split: the model axis is the largest divisor of the device
+                # count that is <= sqrt(n); the data axis takes the rest. This
+                # gives the model axis a real size (>1) on composite device
+                # counts instead of always collapsing it to 1. (T-G)
+                n_devices = int(devices.size)
+                mp = 1
+                for cand in range(int(n_devices ** 0.5), 0, -1):
+                    if n_devices % cand == 0:
+                        mp = cand
                         break
-                mesh_shape = (dp, mp)
+                dp = n_devices // mp
                 self._mesh = Mesh(
-                    devices.reshape(mesh_shape),
+                    devices.reshape((dp, mp)),
                     (data_axis, model_axis)
                 )
             else:
@@ -806,11 +810,13 @@ def broadcast(
     Any
         Broadcasted tensor.
     """
-    if num_devices is None:
-        num_devices = jax.device_count()
-
-    perm = [(src, i) for i in range(num_devices)]
-    return lax.ppermute(tensor, axis_name=axis_name, perm=perm)
+    # A broadcast sends one replica's value to every replica. ``lax.ppermute``
+    # cannot express this (it requires unique sources/destinations), so we
+    # ``all_gather`` along the mapped axis and select the source's slice on
+    # every replica. ``num_devices`` is accepted for API compatibility but is
+    # inferred from the gathered axis. (T-D)
+    gathered = lax.all_gather(tensor, axis_name)
+    return jax.tree.map(lambda g: g[src], gathered)
 
 
 def sync_batch_norm(
@@ -832,12 +838,16 @@ def sync_batch_norm(
     Tuple[Any, Any]
         Synchronized mean and variance.
     """
-    # Compute local statistics
-    mean = jnp.mean(x, axis=0)
-    var = jnp.var(x, axis=0)
+    # Compute the pooled statistics across devices. Averaging per-device
+    # variances is wrong -- it ignores the between-device differences in means
+    # -- so we synchronize the first and second moments and recombine as
+    # Var[x] = E[x^2] - E[x]^2. This assumes equal per-device batch sizes, which
+    # holds under ``pmap``. (T-H)
+    local_mean = jnp.mean(x, axis=0)
+    local_mean_sq = jnp.mean(x * x, axis=0)
 
-    # Synchronize across devices
-    mean = lax.pmean(mean, axis_name=axis_name)
-    var = lax.pmean(var, axis_name=axis_name)
+    mean = lax.pmean(local_mean, axis_name=axis_name)
+    mean_sq = lax.pmean(local_mean_sq, axis_name=axis_name)
+    var = mean_sq - mean ** 2
 
     return mean, var

--- a/braintools/trainer/_trainer.py
+++ b/braintools/trainer/_trainer.py
@@ -86,7 +86,9 @@ class Trainer:
     min_epochs : int, default=1
         Minimum number of training epochs.
     max_steps : int, default=-1
-        Maximum number of training steps. -1 means no limit.
+        Maximum number of training steps. -1 means no limit. A "step" is counted
+        per processed batch; when ``accumulate_grad_batches > 1`` this counts
+        micro-batches rather than optimizer updates.
     val_check_interval : int or float, default=1.0
         How often to run validation within a training epoch.
         Integer = every N batches, float = fraction of epoch.
@@ -617,9 +619,15 @@ class Trainer:
         optimizer = self.optimizers[0] if self.optimizers else None
         state.stage = 'train'
 
-        # Callbacks: epoch start
+        # Callbacks: epoch start. Reset first so the epoch-start hooks log onto a
+        # clean (concrete) slate -- the previous epoch left traced values behind
+        # -- then snapshot whatever they log (e.g. epoch-mode LearningRateMonitor)
+        # so it survives the first per-batch reset and reaches the loggers. (T-A)
+        model._reset_logged_metrics()
         self._callbacks.on_train_epoch_start(self, model)
         model.on_train_epoch_start()
+        epoch_start_logger = dict(model._logger_metrics)
+        epoch_start_prog = dict(model._prog_bar_metrics)
 
         # Reset epoch metrics
         self._epoch_metrics.clear()
@@ -648,6 +656,19 @@ class Trainer:
             # Callbacks: batch start
             self._callbacks.on_train_batch_start(self, model, batch, batch_idx)
             model.on_train_batch_start(batch, batch_idx)
+
+            # Snapshot metrics logged by callbacks/hooks *outside* the traced
+            # step (e.g. LearningRateMonitor). These are concrete values; the
+            # JIT step below resets and repopulates the model dicts with only
+            # ``training_step`` metrics, so without this snapshot they would be
+            # lost. On the first batch, fold in the once-per-epoch metrics. (T-A)
+            pre_logger_metrics = dict(model._logger_metrics)
+            pre_prog_bar_metrics = dict(model._prog_bar_metrics)
+            if batch_idx == 0:
+                for k, v in epoch_start_logger.items():
+                    pre_logger_metrics.setdefault(k, v)
+                for k, v in epoch_start_prog.items():
+                    pre_prog_bar_metrics.setdefault(k, v)
 
             # Single forward + backward pass; metrics come back concrete.
             grads, loss, aux = compute_grads_fn(batch, batch_idx)
@@ -679,6 +700,10 @@ class Trainer:
             logger_metrics = aux.get('logger', {}) if isinstance(aux, dict) else {}
             prog_bar_metrics = aux.get('prog_bar', {}) if isinstance(aux, dict) else {}
             outputs = {'loss': loss_val}
+            # Callback/hook metrics first; training_step metrics take precedence
+            # on any name collision. (T-A)
+            for key, value in pre_logger_metrics.items():
+                outputs[key] = _to_scalar(value)
             for key, value in logger_metrics.items():
                 outputs[key] = _to_scalar(value)
 
@@ -696,6 +721,7 @@ class Trainer:
             if pbar is not None:
                 pbar.update(1)
                 pbar_show = {'loss': loss_val}
+                pbar_show.update({k: _to_scalar(v) for k, v in pre_prog_bar_metrics.items()})
                 pbar_show.update({k: _to_scalar(v) for k, v in prog_bar_metrics.items()})
                 pbar.set_postfix(pbar_show)
 
@@ -899,9 +925,16 @@ class Trainer:
                 if i < len(self.optimizers):
                     self.optimizers[i].load_state_dict(single)
 
-        self.state.epoch = state.get('epoch', 0)
+        # Coerce missing/None counters to 0. ``CheckpointManager`` may store
+        # ``step=None`` (and hence no 'global_step'), which would otherwise make
+        # ``global_step`` None and crash the loop on ``global_step += 1``. (T-C)
+        epoch = state.get('epoch')
+        self.state.epoch = epoch if epoch is not None else 0
         # Prefer 'global_step'; fall back to the legacy 'step' key.
-        self.state.global_step = state.get('global_step', state.get('step', 0))
+        gstep = state.get('global_step')
+        if gstep is None:
+            gstep = state.get('step')
+        self.state.global_step = gstep if gstep is not None else 0
         if self.model is not None:
             self.model.current_epoch = self.state.epoch
             self.model.global_step = self.state.global_step

--- a/docs/braintools-trainer-issues-found-20260619.md
+++ b/docs/braintools-trainer-issues-found-20260619.md
@@ -1,0 +1,235 @@
+# `braintools.trainer` — Issues Found and Proposed Solutions (2026-06-19)
+
+A senior-developer / JAX-expert audit of the `braintools/trainer/` module and its
+documentation (`docs/apis/trainer.rst`). Each issue below was reviewed in source;
+the four high/medium issues were additionally **reproduced** with runnable probes
+against the current code.
+
+Environment: `jax==0.10.2`, `brainstate==0.5.1`. Baseline before fixes: **489
+trainer tests pass**.
+
+Files audited: `_module.py`, `_trainer.py`, `_callbacks.py`, `_loggers.py`,
+`_dataloader.py`, `_distributed.py`, `_checkpoint.py`, `_progress.py`.
+
+---
+
+## Summary table
+
+| ID  | Severity | Area | One-line description | Status |
+|-----|----------|------|----------------------|--------|
+| T-A | High | trainer/callbacks | Metrics logged via `module.log()` inside callbacks/hooks never reach loggers or the progress bar (breaks `LearningRateMonitor`). | Fixed |
+| T-B | High | callbacks | `ModelCheckpoint(save_top_k=k)` writes one checkpoint **per epoch** to disk; evicted files are never deleted. | Fixed |
+| T-C | Medium | trainer/checkpoint | Resuming from a `CheckpointManager` checkpoint saved with `step=None` sets `global_step=None` and crashes the training loop. | Fixed |
+| T-D | Medium | distributed | `broadcast()` / `Strategy.broadcast()` build an invalid `lax.ppermute` and raise on >1 device. | Fixed |
+| T-E | Low | callbacks/docs | `GradientClipCallback` is a no-op (even with `log_grad_norm=True`) but its docstring implies it clips/logs. | Fixed (docs) |
+| T-F | Low | trainer/docs | Under `accumulate_grad_batches>1`, `max_steps` counts micro-batches, not optimizer steps. | Fixed (docs) |
+| T-G | Low | distributed | FSDP auto-mesh with `model_axis` always produces a model axis of size 1. | Fixed |
+| T-H | Low | distributed | `sync_batch_norm` averages per-device variances, underestimating the true global variance. | Fixed |
+| T-I | Low | dataloader/docs | `create_distributed_batches` silently drops the trailing incomplete batch. | Fixed (docs) |
+| T-J | Low | callbacks/docs | `LearningRateMonitor(log_momentum=...)` is accepted but never used. | Fixed (docs) |
+
+---
+
+## T-A (High) — `module.log()` from callbacks/hooks never reaches loggers/progress bar
+
+**Where:** `_trainer.py` `Trainer._create_train_step` / `_run_train_epoch`;
+manifests through `_callbacks.py` `LearningRateMonitor`.
+
+**Problem.** The JIT-traced `loss_fn` calls `model._reset_logged_metrics()` and
+then runs `training_step`, capturing **only** `training_step`'s logged metrics
+into the gradient `aux`:
+
+```python
+def loss_fn(batch, batch_idx):
+    model._reset_logged_metrics()          # wipes anything logged earlier this batch
+    outputs = model.training_step(batch, batch_idx)
+    ...
+    aux = {'logger': dict(model._logger_metrics), 'prog_bar': dict(model._prog_bar_metrics)}
+    return loss, aux
+```
+
+The training loop logs/displays from `aux` only. Consequently, anything a
+callback or hook logs via `module.log()` during `on_train_batch_start` (e.g.
+`LearningRateMonitor` in `'step'` mode) — or during `on_train_epoch_start` for
+`'epoch'` mode — is (a) erased by the reset inside `loss_fn`, and (b) never
+present in `aux`. The metric silently disappears from loggers and the progress
+bar. (`LearningRateMonitor.lr_history` is still populated, which masks the bug.)
+
+**Reproduction.** A spy `Logger` over a 1-epoch fit with a `LearningRateMonitor`
+captured only `['loss', 'train_loss']`; `lr-opt0` never appeared, even though
+`lr_history == [{'lr-opt0': 0.001}, ...]`.
+
+**Fix.** In `_run_train_epoch`, snapshot the metrics logged outside JIT — at
+epoch start and right after the per-batch start hooks — and merge them into the
+per-batch `outputs` and progress-bar postfix, with `training_step` metrics taking
+precedence on name collisions. These callback/hook values are concrete (logged
+outside the traced step), so they are safe to read directly.
+
+---
+
+## T-B (High) — `ModelCheckpoint(save_top_k=k)` leaves orphan checkpoint files
+
+**Where:** `_callbacks.py` `ModelCheckpoint._checkpoint_epoch` / `_update_best_k`.
+
+**Problem.** `_checkpoint_epoch` calls `_update_best_k(score, filepath)` (which
+may immediately evict the just-added `filepath` if it is the worst) **before**
+`_save_checkpoint(...)`, and `_save_checkpoint` writes unconditionally:
+
+```python
+self._update_best_k(current_score, filepath)   # may del filepath from tracking,
+                                                # _remove_checkpoint() is a no-op (file not written yet)
+self._save_checkpoint(trainer, module, filepath)  # ...but this writes it anyway
+```
+
+So a checkpoint that was "evicted" from the top-k is still written to disk and
+never tracked or cleaned up. `save_top_k` is not enforced on disk.
+
+**Reproduction.** With `save_top_k=2` over 6 epochs (monotonically worsening
+`val_loss`): **6** `.ckpt` files on disk, but only **2** tracked in
+`best_k_models`.
+
+**Fix.** Save first, then prune: call `_save_checkpoint(...)` and then
+`_update_best_k(...)`. Eviction's `_remove_checkpoint` now finds and deletes the
+file, so disk stays at `save_top_k`. The best checkpoint is never the eviction
+target (it holds the best score), so it is preserved.
+
+---
+
+## T-C (Medium) — resuming from a `step=None` checkpoint crashes
+
+**Where:** `_trainer.py` `Trainer._load_checkpoint`; `_checkpoint.py`
+`CheckpointManager.save`.
+
+**Problem.** `CheckpointManager.save(..., step=None)` stores `'step': None`.
+On resume:
+
+```python
+self.state.global_step = state.get('global_step', state.get('step', 0))  # -> None
+...
+state.global_step += 1   # TypeError: unsupported operand type(s) for +=: 'NoneType' and 'int'
+```
+
+**Reproduction.** Saving with `step=None` then `trainer.fit(..., ckpt_path=...)`
+raised `TypeError: unsupported operand type(s) for +=: 'NoneType' and 'int'`.
+
+**Fix.** Coerce a missing/`None` `global_step` (and `epoch`) to `0` on load.
+
+---
+
+## T-D (Medium) — `broadcast()` / `Strategy.broadcast()` use an invalid `ppermute`
+
+**Where:** `_distributed.py` module-level `broadcast`, `DataParallelStrategy.broadcast`
+(and `AutoStrategy.broadcast` which delegates).
+
+**Problem.** The permutation repeats the source index as a source for every
+destination:
+
+```python
+perm = [(src, i) for i in range(num_devices)]
+return lax.ppermute(tensor, axis_name=axis_name, perm=perm)
+```
+
+`lax.ppermute` requires unique sources and destinations.
+
+**Reproduction.** On 4 fake CPU devices
+(`XLA_FLAGS=--xla_force_host_platform_device_count=4`):
+`ValueError: ppermute sources and destinations must be unique, got ((0,0),(0,1),(0,2),(0,3))`.
+(`all_reduce` works correctly.)
+
+**Fix.** Implement broadcast with a valid collective:
+`lax.all_gather(x, axis_name)[src]` per leaf — every replica gathers all values
+and selects the source's, yielding a correct broadcast for any device count.
+
+---
+
+## T-E (Low) — `GradientClipCallback` is a no-op; docstring is misleading
+
+**Where:** `_callbacks.py` `GradientClipCallback`.
+
+`on_before_optimizer_step` is a `pass`; `log_grad_norm` is never read. Gradient
+clipping is performed by the `Trainer` (`gradient_clip_val`/`gradient_clip_algorithm`)
+inside the JIT-compiled apply step, where a Python callback cannot intercept the
+gradients. The class therefore does nothing.
+
+**Fix.** Clarify the docstring: the callback does not currently clip or log;
+use `Trainer(gradient_clip_val=...)`. (Behavior unchanged — the Trainer owns
+clipping; intercepting traced grads from a callback is out of scope.)
+
+---
+
+## T-F (Low) — `max_steps` semantics under gradient accumulation
+
+**Where:** `_trainer.py` `_run_train_epoch`.
+
+`state.global_step` increments once per **micro-batch**, while the optimizer
+steps once per `accumulate_grad_batches` micro-batches. So with
+`accumulate_grad_batches>1`, `max_steps` bounds processed batches, not optimizer
+updates.
+
+**Fix.** Document this in the `Trainer` docstring (`max_steps` / `accumulate_grad_batches`).
+
+---
+
+## T-G (Low) — FSDP auto-mesh collapses the model axis to size 1
+
+**Where:** `_distributed.py` `FullyShardedDataParallelStrategy.__init__`.
+
+When `model_axis` is given and no `mesh` is supplied, the balancing loop
+`for dp in [n_devices, n_devices//2, n_devices//4]` succeeds immediately at
+`dp=n_devices, mp=1`, so the model-parallel axis always has size 1 — defeating
+the purpose of `model_axis`.
+
+**Fix.** Search for the most balanced 2-D factorization (largest `dp ≤ sqrt(n)`
+dividing `n`, with `mp = n/dp`), so the model axis gets a real size when the
+device count allows.
+
+---
+
+## T-H (Low) — `sync_batch_norm` underestimates global variance
+
+**Where:** `_distributed.py` `sync_batch_norm` (note: not exported in `__all__`).
+
+It computes per-device variance and then `pmean`s the variances. The mean of
+per-device variances ignores the between-device differences in means, so it is
+**not** the true pooled variance.
+
+**Fix.** Compute global variance as `pmean(E[x²]) - pmean(E[x])²`.
+
+---
+
+## T-I (Low) — `create_distributed_batches` silently drops the remainder
+
+**Where:** `_dataloader.py` `create_distributed_batches`.
+
+The loop `range(0, n_samples - total_batch_size + 1, total_batch_size)` drops any
+trailing samples that do not fill a full `num_devices × batch_size` block, with
+no warning. This is reasonable for `pmap` (which needs a fixed leading device
+axis), but it is undocumented.
+
+**Fix.** Document the drop-remainder behavior in the function docstring.
+
+---
+
+## T-J (Low) — `LearningRateMonitor(log_momentum=...)` is accepted but unused
+
+**Where:** `_callbacks.py` `LearningRateMonitor`.
+
+`log_momentum` is stored but never read.
+
+**Fix.** Document that momentum logging is not yet implemented.
+
+---
+
+## Other observations (reviewed, no change)
+
+- **JIT metric capture for `training_step`:** metrics logged inside
+  `training_step` are correctly returned as concrete `aux` and are re-evaluated
+  per batch; the design is sound. Custom callbacks that read `module.logged_metrics`
+  directly during `on_train_batch_end` may still observe stale traced values —
+  callbacks should use the `outputs` argument (concrete) instead. (Documented
+  limitation; not changed.)
+- **`DataLoader` epoch reshuffling** (`__iter__` advances `_epoch` before yielding)
+  is correct and reproducible for a given `(seed, epoch)`.
+- **`CSVLogger`** header-widening / rewrite on newly-appearing metric columns is
+  correct.
+- **`SimpleProgressBar`** overshoot clamping (T-30) is correct.


### PR DESCRIPTION
## Summary

A senior-developer / JAX-expert audit of `braintools/trainer/` and its docs. Full
findings + proposed solutions are in `docs/braintools-trainer-issues-found-20260619.md`.
This PR fixes every issue found.

### High
- **T-A** Metrics logged via `module.log()` from callbacks/hooks (e.g. `LearningRateMonitor`) were wiped by the JIT `loss_fn` reset and absent from the grad `aux`, so they never reached loggers or the progress bar. The loop now snapshots pre-step (and epoch-start) logged metrics and merges them into the per-batch outputs (`training_step` metrics win on collision).
- **T-B** `ModelCheckpoint(save_top_k=k)` wrote a checkpoint every epoch and never deleted evicted ones (pruning ran before the save). Save now precedes prune, so disk respects `save_top_k`.

### Medium
- **T-C** Resuming from a `CheckpointManager` checkpoint saved with `step=None` set `global_step=None` and crashed the loop. Missing/None counters now coerce to `0`.
- **T-D** `broadcast()` / `Strategy.broadcast()` built an invalid `lax.ppermute` and raised on >1 device. Reimplemented via `lax.all_gather()[src]`.

### Low / docs
- **T-G** FSDP auto-mesh with `model_axis` always collapsed the model axis to size 1 → now uses the most balanced 2-D factorization.
- **T-H** `sync_batch_norm` averaged per-device variances → now pools via `E[x²]-E[x]²`.
- **T-E/T-F/T-I/T-J** docstring clarifications (`GradientClipCallback` no-op; `max_steps` counts micro-batches under accumulation; `create_distributed_batches` drops remainder; `LearningRateMonitor.log_momentum` unimplemented).

## Testing
- New regression tests in `braintools/trainer/_audit_20260619_test.py` (multi-device collective/mesh tests run in a subprocess with fake CPU devices).
- Full trainer suite: **497 passed** (489 baseline + 8 new), no regressions.