### PR TITLE
fix(metric): correctness, brainunit, and edge-case fixes across braintools.metric

### DIFF
--- a/braintools/metric/__init__.py
+++ b/braintools/metric/__init__.py
@@ -427,6 +427,7 @@ from ._regression import (
     log_cosh,
     cosine_similarity,
     cosine_distance,
+    L1Loss,
 )
 
 # Smoothing utilities
@@ -502,6 +503,7 @@ __all__ = [
     'log_cosh',
     'cosine_similarity',
     'cosine_distance',
+    'L1Loss',
 
     # Smoothing utilities
     'smooth_labels',

--- a/braintools/metric/_audit_20260619_test.py
+++ b/braintools/metric/_audit_20260619_test.py
@@ -1,0 +1,255 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Regression tests for the 2026-06-19 ``braintools.metric`` audit.
+
+Each test reproduces a specific finding from
+``docs/braintools-metric-issues-found-20260619.md`` (IDs referenced in the test
+names) and pins the corrected behaviour.
+"""
+
+import unittest
+
+import brainstate
+import brainunit as u
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import braintools.metric as m
+from braintools.metric._lfp import _analytic_band
+from braintools.metric._firings import victor_purpura_distance
+
+
+class TestFIR1PhaseLockingQuantityDt(unittest.TestCase):
+    def _spikes(self):
+        rng = np.random.RandomState(0)
+        return jnp.asarray((rng.rand(1000, 5) < 0.1).astype(float))
+
+    def test_quantity_dt_does_not_crash(self):
+        # FIR-1: a brainunit.Quantity dt previously raised TypeError in jnp.exp.
+        spikes = self._spikes()
+        plv = m.phase_locking_value(spikes, 10.0, dt=0.1 * u.ms)
+        self.assertEqual(plv.shape, (5,))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(plv))))
+
+    def test_quantity_dt_matches_equivalent_seconds(self):
+        # FIR-1: a Quantity dt must be interpreted in seconds (reference_freq is Hz),
+        # so 0.1 ms must equal the float value 1e-4 s.
+        spikes = self._spikes()
+        plv_q = m.phase_locking_value(spikes, 10.0, dt=0.1 * u.ms)
+        plv_f = m.phase_locking_value(spikes, 10.0, dt=1e-4)
+        np.testing.assert_allclose(np.asarray(plv_q), np.asarray(plv_f), rtol=1e-5, atol=1e-6)
+
+
+class TestCOR2CrossCorrelationQuantity(unittest.TestCase):
+    def test_quantity_input_does_not_crash(self):
+        # COR-2: a Quantity spike matrix previously raised TypeError in jnp.sum.
+        rng = np.random.RandomState(1)
+        sp = jnp.asarray((rng.rand(50, 3) < 0.2).astype(float))
+        out_q = m.cross_correlation(sp * u.UNITLESS, 5.0, dt=1.0)
+        out_plain = m.cross_correlation(sp, 5.0, dt=1.0)
+        np.testing.assert_allclose(float(out_q), float(out_plain), rtol=1e-6)
+
+
+class TestPW1PairwiseCosineSmallVectors(unittest.TestCase):
+    def test_small_identical_rows_have_unit_similarity(self):
+        # PW-1: flooring the *product* of norms corrupted small (non-zero) vectors.
+        X = jnp.array([[3e-5, 0.0], [3e-5, 0.0]])
+        sim = m.pairwise_cosine_similarity(X)
+        np.testing.assert_allclose(float(sim[0, 0]), 1.0, atol=1e-5)
+        np.testing.assert_allclose(float(sim[0, 1]), 1.0, atol=1e-5)
+
+    def test_orthogonal_small_rows(self):
+        X = jnp.array([[1e-5, 0.0], [0.0, 1e-5]])
+        sim = m.pairwise_cosine_similarity(X)
+        np.testing.assert_allclose(float(sim[0, 1]), 0.0, atol=1e-5)
+
+    def test_zero_vector_still_yields_zero(self):
+        # The documented zero-vector behaviour must be preserved.
+        X = jnp.array([[0.0, 0.0], [1.0, 2.0]])
+        sim = m.pairwise_cosine_similarity(X)
+        np.testing.assert_allclose(float(sim[0, 1]), 0.0, atol=1e-6)
+
+    def test_zero_vector_gradient_is_finite(self):
+        def f(x):
+            return jnp.sum(m.pairwise_cosine_similarity(x))
+
+        g = jax.grad(f)(jnp.array([[0.0, 0.0], [1.0, 2.0]]))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(g))))
+
+
+class TestREG6L1LossScalar(unittest.TestCase):
+    def test_scalar_input_does_not_crash(self):
+        # REG-6: 0-d inputs previously raised IndexError via logits.shape[0].
+        out = m.l1_loss(jnp.array(1.0), jnp.array(1.5))
+        np.testing.assert_allclose(float(out), 0.5, atol=1e-6)
+
+    def test_one_d_input_unchanged(self):
+        out = m.l1_loss(jnp.array([1.0, 3.0]), jnp.array([1.5, 2.0]))
+        # per-sample MAE of [|1-1.5|, |3-2|] = [0.5, 1.0]; mean = 0.75
+        np.testing.assert_allclose(float(out), 0.75, atol=1e-6)
+
+
+class TestINIT1L1LossExport(unittest.TestCase):
+    def test_l1loss_importable_from_metric(self):
+        # INIT-1: L1Loss is a documented public class that was missing from
+        # braintools.metric.__all__ / __init__, so the import raised ImportError.
+        from braintools.metric import L1Loss  # noqa: F401
+        self.assertTrue(hasattr(m, 'L1Loss'))
+        self.assertIn('L1Loss', m.__all__)
+
+    def test_l1loss_update_matches_l1_loss(self):
+        from braintools.metric import L1Loss
+        logits = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+        targets = jnp.array([[1.5, 2.5], [2.0, 4.0]])
+        for reduction in ('mean', 'sum', 'none'):
+            crit = L1Loss(reduction)
+            np.testing.assert_allclose(
+                np.asarray(crit.update(logits, targets)),
+                np.asarray(m.l1_loss(logits, targets, reduction=reduction)),
+                atol=1e-6,
+            )
+
+
+class TestSM1SmoothLabelsValidation(unittest.TestCase):
+    def test_integer_labels_raise_type_error(self):
+        # SM-1: validation must use a real exception (survives `python -O`).
+        with self.assertRaises(TypeError):
+            m.smooth_labels(jnp.array([[1, 0, 0], [0, 1, 0]]), 0.1)
+
+
+class TestLFP1PhaseCoherenceEmptyBand(unittest.TestCase):
+    def test_empty_band_off_diagonal_is_zero(self):
+        # LFP-1: an empty band must not report spurious phase coherence.
+        t = np.arange(0, 2, 0.001)
+        sig = np.column_stack([np.sin(2 * np.pi * 10 * t), np.cos(2 * np.pi * 30 * t)])
+        coh = m.lfp_phase_coherence(jnp.asarray(sig), 0.001, freq_band=(200, 300))
+        np.testing.assert_allclose(float(coh[0, 1]), 0.0, atol=1e-3)
+        # Diagonal is 1 by definition.
+        np.testing.assert_allclose(np.asarray(jnp.diag(coh)), 1.0, atol=1e-6)
+
+    def test_in_band_signals_still_coherent(self):
+        # A real in-band signal must keep its (high) coherence.
+        t = np.arange(0, 2, 0.001)
+        sig = np.sin(2 * np.pi * 10 * t)
+        sigs = jnp.asarray(np.column_stack([sig, sig, sig]))
+        coh = m.lfp_phase_coherence(sigs, 0.001, freq_band=(8, 12))
+        self.assertTrue(bool(jnp.all(coh >= 0.8)))
+
+
+class TestLFP2CoherenceEmptyFreqRange(unittest.TestCase):
+    def test_empty_freq_range_returns_single_bin(self):
+        # LFP-2: mirror power_spectral_density's empty-range fallback.
+        rng = np.random.RandomState(2)
+        sig = jnp.asarray(rng.randn(2000))
+        freqs, coh = m.coherence_analysis(sig, sig, 0.001, freq_range=(1e5, 2e5))
+        self.assertEqual(freqs.shape[0], 1)
+        self.assertEqual(coh.shape[0], 1)
+
+
+class TestLFP3CoherenceScaleInvariance(unittest.TestCase):
+    def test_downscaled_identical_signals_remain_coherent(self):
+        # LFP-3: an absolute 1e-15 floor biased down-scaled signals toward 0.
+        rng = np.random.RandomState(3)
+        base = rng.randn(4000)
+        big = jnp.asarray(base)
+        small = jnp.asarray(base * 1e-6)
+        _, coh_big = m.coherence_analysis(big, big, 0.001)
+        _, coh_small = m.coherence_analysis(small, small, 0.001)
+        # Identical signals -> coherence 1 at populated bins, regardless of scale.
+        np.testing.assert_allclose(float(jnp.max(coh_small)), float(jnp.max(coh_big)), atol=1e-4)
+        self.assertGreater(float(jnp.max(coh_small)), 0.99)
+
+
+class TestLFP5AnalyticBandDC(unittest.TestCase):
+    def test_dc_bin_not_doubled(self):
+        # LFP-5: including 0 Hz in a band previously doubled the DC component.
+        n = 64
+        const = 3.0
+        sig = jnp.full((n, 1), const)
+        freqs = jnp.fft.fftfreq(n, 1.0)
+        fft = jnp.fft.fft(sig, axis=0)
+        analytic = _analytic_band(fft, freqs, low=0.0, high=10.0)
+        # The reconstructed analytic signal's real part must equal the DC value,
+        # not 2x it.
+        np.testing.assert_allclose(float(jnp.real(analytic[0, 0])), const, atol=1e-4)
+
+
+class TestCLS2SigmoidBCEListInputs(unittest.TestCase):
+    def test_list_inputs_accepted(self):
+        # CLS-2: list inputs previously raised AttributeError on .astype/.dtype.
+        out = m.sigmoid_binary_cross_entropy([1.0, -1.0], [1.0, 0.0])
+        ref = m.sigmoid_binary_cross_entropy(jnp.array([1.0, -1.0]), jnp.array([1.0, 0.0]))
+        np.testing.assert_allclose(np.asarray(out), np.asarray(ref), atol=1e-6)
+
+
+class TestFIR3BurstSynchronyEndpointTouch(unittest.TestCase):
+    def test_endpoint_touching_bursts_count_as_synchronous(self):
+        # FIR-3: bursts that touch at a single instant are the strongest synchrony
+        # and must not be excluded by a strict `> 0` overlap test.
+        spikes = np.zeros((20, 2))
+        spikes[0:5, 0] = 1.0   # neuron 0 burst spans t=0..4
+        spikes[4:9, 1] = 1.0   # neuron 1 burst spans t=4..8 (touches at t=4)
+        idx = m.burst_synchrony_index(jnp.asarray(spikes), burst_threshold=3,
+                                      max_isi=2.0, dt=1.0)
+        self.assertGreater(float(idx), 0.0)
+
+
+class TestFIR2VictorPurpuraCorrectness(unittest.TestCase):
+    def test_identical_trains_zero_distance(self):
+        s = jnp.array([1.0, 2.0, 3.0])
+        self.assertAlmostEqual(victor_purpura_distance(s, s, cost_factor=1.0), 0.0, places=5)
+
+    def test_single_extra_spike_costs_one(self):
+        s1 = jnp.array([1.0, 2.0])
+        s2 = jnp.array([1.0, 2.0, 3.0])
+        self.assertAlmostEqual(victor_purpura_distance(s1, s2, cost_factor=1.0), 1.0, places=5)
+
+    def test_small_shift_costs_q_times_delta(self):
+        s1 = jnp.array([1.0])
+        s2 = jnp.array([1.1])
+        # cheaper to shift (q*0.1=0.5) than delete+insert (=2)
+        self.assertAlmostEqual(victor_purpura_distance(s1, s2, cost_factor=5.0), 0.5, places=5)
+
+    def test_far_shift_prefers_delete_insert(self):
+        s1 = jnp.array([1.0])
+        s2 = jnp.array([100.0])
+        # shifting costs q*99 = 99 >> delete+insert = 2
+        self.assertAlmostEqual(victor_purpura_distance(s1, s2, cost_factor=1.0), 2.0, places=5)
+
+
+class TestFIR6CorrelationIndexBounds(unittest.TestCase):
+    def test_result_within_pm_one(self):
+        rng = np.random.RandomState(4)
+        base = (rng.rand(1000, 1) < 0.1).astype(float)
+        spikes = jnp.asarray(np.concatenate([base, base, rng.rand(1000, 1) < 0.1], axis=1).astype(float))
+        ci = m.correlation_index(spikes, window_size=50.0, dt=1.0)
+        self.assertGreaterEqual(float(ci), -1.0)
+        self.assertLessEqual(float(ci), 1.0)
+
+
+class TestCOR4CrossCorrelationZeroBranch(unittest.TestCase):
+    def test_all_silent_pair_returns_zero(self):
+        # Exercises the lax.cond zero branch (COR-4); must be a clean 0.0.
+        spikes = jnp.zeros((100, 3))
+        out = m.cross_correlation(spikes, bin=10.0, dt=1.0, method='loop')
+        np.testing.assert_allclose(float(out), 0.0, atol=1e-7)
+        out_v = m.cross_correlation(spikes, bin=10.0, dt=1.0, method='vmap')
+        np.testing.assert_allclose(float(out_v), 0.0, atol=1e-7)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/braintools/metric/_classification.py
+++ b/braintools/metric/_classification.py
@@ -102,7 +102,7 @@ def sigmoid_binary_cross_entropy(
     >>> labels = jnp.array([1.0, 0.0, 1.0])
     >>> loss = braintools.metric.sigmoid_binary_cross_entropy(logits, labels)
     >>> print(loss)
-    [0.31326166 0.31326166 0.6931472 ]
+    [0.3132617 0.3132617 0.6931472]
 
     References
     ----------
@@ -110,7 +110,8 @@ def sigmoid_binary_cross_entropy(
            "Deep learning." MIT press, 2016.
            http://www.deeplearningbook.org/contents/prob.html
     """
-    labels = labels.astype(logits.dtype)
+    logits = jnp.asarray(logits)
+    labels = jnp.asarray(labels).astype(logits.dtype)
     log_p = jax.nn.log_sigmoid(logits)
     log_not_p = jax.nn.log_sigmoid(-logits)
     return -labels * log_p - (1. - labels) * log_not_p
@@ -192,7 +193,7 @@ def perceptron_loss(
     >>> targets = jnp.array([1, -1, 1])
     >>> loss = braintools.metric.perceptron_loss(predictions, targets)
     >>> print(loss)
-    [0.  0.  0. ]
+    [0. 0. 0.]
 
     References
     ----------
@@ -240,7 +241,7 @@ def softmax_cross_entropy(
     >>> labels = jnp.array([[1.0, 0.0, 0.0]])
     >>> loss = braintools.metric.softmax_cross_entropy(logits, labels)
     >>> print(loss)
-    [0.4170299]
+    [0.41702995]
 
     References
     ----------
@@ -288,7 +289,7 @@ def softmax_cross_entropy_with_integer_labels(
     >>> labels = jnp.array([0])  # Class 0
     >>> loss = braintools.metric.softmax_cross_entropy_with_integer_labels(logits, labels)
     >>> print(loss)
-    [0.4170299]
+    [0.41702995]
 
     Notes
     -----
@@ -363,7 +364,7 @@ def multiclass_hinge_loss(
     >>> labels = jnp.array([1, 2])  # Correct classes
     >>> loss = braintools.metric.multiclass_hinge_loss(scores, labels)
     >>> print(loss)
-    [0.  0. ]
+    [0.        0.5999999]
 
     References
     ----------
@@ -421,7 +422,7 @@ def multiclass_perceptron_loss(
     >>> labels = jnp.array([1, 2])  # Correct classes
     >>> loss = braintools.metric.multiclass_perceptron_loss(scores, labels)
     >>> print(loss)
-    [0.  0. ]
+    [0. 0.]
 
     References
     ----------
@@ -1017,6 +1018,13 @@ def sigmoid_focal_loss(
 
     The alpha parameter is typically set to the inverse class frequency for
     the positive class, e.g., alpha=0.25 when positive examples are 25% of data.
+
+    The modulating factor ``(1 - p_t) ** gamma`` has a non-finite gradient when a
+    *fractional* focusing parameter (``0 < gamma < 1``) meets a perfectly
+    classified, saturated example (``p_t -> 1``), because ``d/dx x**gamma`` is
+    unbounded at ``x = 0``. This matches the reference optax/fvcore behaviour; the
+    default ``gamma = 2.0`` (and any ``gamma >= 1``) is gradient-safe. Prefer
+    integer/``>= 1`` ``gamma`` values when differentiating through saturated logits.
 
     References
     ----------

--- a/braintools/metric/_correlation.py
+++ b/braintools/metric/_correlation.py
@@ -119,6 +119,8 @@ def cross_correlation(
     if bin_size < 1:
         raise ValueError(f'`bin` ({bin}) must be at least as large as `dt` ({dt}); '
                          f'got a bin width of {bin_size} samples.')
+    # Strip units so ``Quantity`` spike matrices behave like the other metrics.
+    spikes = jnp.asarray(u.get_magnitude(spikes))
     num_hist, num_neu = spikes.shape
     if num_neu < 2:
         # Coincidence is only defined for pairs; a single neuron has no pairs.
@@ -134,7 +136,7 @@ def cross_correlation(
         def _f(i, j):
             sqrt_ij = jnp.sqrt(jnp.sum(states[i]) * jnp.sum(states[j]))
             return lax.cond(sqrt_ij == 0.,
-                            lambda _: 0.,
+                            lambda _: jnp.zeros((), dtype=sqrt_ij.dtype),
                             lambda _: jnp.sum(states[i] * states[j]) / sqrt_ij,
                             None)
 
@@ -145,7 +147,7 @@ def cross_correlation(
         def _cc(i, j):
             sqrt_ij = jnp.sqrt(jnp.sum(states[i]) * jnp.sum(states[j]))
             return lax.cond(sqrt_ij == 0.,
-                            lambda _: 0.,
+                            lambda _: jnp.zeros((), dtype=sqrt_ij.dtype),
                             lambda _: jnp.sum(states[i] * states[j]) / sqrt_ij,
                             None)
 
@@ -213,9 +215,11 @@ def voltage_fluctuation(
     Returns
     -------
     jax.Array
-        Scalar (0-d array) synchronization index. Values > 1 indicate synchronized
-        activity, values ≈ 1 indicate asynchronous activity. By convention a
-        constant (zero-variance) population returns ``1.0``.
+        Scalar (0-d array) synchronization index, bounded in approximately
+        ``[1/N, 1]``. Values near ``1`` indicate strong synchrony; values near
+        ``1/N`` indicate asynchronous activity. (The ratio of the population-mean
+        variance to the mean single-neuron variance cannot exceed 1.) By
+        convention a constant (zero-variance) population returns ``1.0``.
 
     Examples
     --------
@@ -449,11 +453,14 @@ def functional_connectivity_dynamics(
 
     Examples
     --------
-    >>> import jax.numpy as jnp
-    >>> import braintools as braintools
-    >>> import brainstate as brainstate
-    >>> activities = brainstate.random.rand(200, 10)
-    >>> fcd = braintools.metric.functional_connectivity_dynamics(activities)
+    .. code-block:: python
+
+        >>> import braintools
+        >>> import brainstate
+        >>> activities = brainstate.random.rand(200, 10)
+        >>> fcd = braintools.metric.functional_connectivity_dynamics(activities)
+        >>> fcd.shape
+        (35, 35)
     """
 
     if activities.ndim != 2:
@@ -552,24 +559,18 @@ def weighted_correlation(
 
     Examples
     --------
-    >>> import jax.numpy as jnp
-    >>> import braintools as braintools
-    >>> # Perfect linear relationship
-    >>> x = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0])
-    >>> y = jnp.array([2.0, 4.0, 6.0, 8.0, 10.0])
-    >>> # Weight middle points more heavily
-    >>> w = jnp.array([1.0, 1.0, 2.0, 2.0, 1.0])
-    >>> corr = braintools.metric.weighted_correlation(x, y, w)
-    >>> print(f"Weighted correlation: {corr:.3f}")
-    >>>
-    >>> # Compare with unweighted correlation
-    >>> unweighted = jnp.corrcoef(x, y)[0, 1]
-    >>> print(f"Unweighted correlation: {unweighted:.3f}")
-    >>>
-    >>> # Example with reliability weights (higher for more reliable measurements)
-    >>> reliability = jnp.array([0.5, 0.8, 0.9, 0.7, 0.6])
-    >>> corr_reliable = braintools.metric.weighted_correlation(x, y, reliability)
-    >>> print(f"Reliability-weighted: {corr_reliable:.3f}")
+    .. code-block:: python
+
+        >>> import jax.numpy as jnp
+        >>> import braintools
+        >>> # Perfect linear relationship y = 2x.
+        >>> x = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        >>> y = jnp.array([2.0, 4.0, 6.0, 8.0, 10.0])
+        >>> # Weight middle points more heavily.
+        >>> w = jnp.array([1.0, 1.0, 2.0, 2.0, 1.0])
+        >>> corr = braintools.metric.weighted_correlation(x, y, w)
+        >>> print(f"Weighted correlation: {corr:.3f}")
+        Weighted correlation: 1.000
     """
 
     x = jnp.asarray(u.get_magnitude(x))

--- a/braintools/metric/_correlation_test.py
+++ b/braintools/metric/_correlation_test.py
@@ -144,7 +144,7 @@ class TestVoltageFluctuation(unittest.TestCase):
         voltages = jnp.array(voltages).T
 
         sync_index = braintools.metric.voltage_fluctuation(voltages)
-        # Synchronized signals should have sync_index > 1
+        # Synchronized signals push the index toward its upper bound of 1.
         self.assertGreater(float(sync_index), 0.5)  # More relaxed threshold
 
     def test_voltage_fluctuation_asynchronous(self):
@@ -153,9 +153,9 @@ class TestVoltageFluctuation(unittest.TestCase):
         voltages = self.rng.normal(0, 1, size=(100, 10))
         sync_index = braintools.metric.voltage_fluctuation(voltages)
 
-        # Asynchronous signals should have sync_index around 1, but can vary
+        # Asynchronous signals have a small index (~1/N); it stays within [0, 1].
         self.assertGreater(float(sync_index), 0.0)
-        self.assertLess(float(sync_index), 10.0)  # Reasonable upper bound
+        self.assertLessEqual(float(sync_index), 1.0 + 1e-4)
 
     def test_voltage_fluctuation_constant(self):
         """Test voltage fluctuation for constant signals."""

--- a/braintools/metric/_fenchel_young.py
+++ b/braintools/metric/_fenchel_young.py
@@ -58,9 +58,11 @@ def make_fenchel_young_loss(
 
     where :math:`\theta` are the scores and :math:`y` is the target. ``max_fun``
     is exactly this conjugate :math:`\Omega^*` (NOT the regularizer
-    :math:`\Omega` itself). The loss is convex in :math:`\theta`, non-negative,
-    and minimized when the prediction matches the target. Its gradient w.r.t.
-    the scores is
+    :math:`\Omega` itself). When ``max_fun`` is a genuine convex conjugate and
+    the target :math:`y` lies in the marginal polytope :math:`\mathcal{C}`, the
+    loss is convex in :math:`\theta`, non-negative, and zero iff the prediction
+    matches the target. (These guarantees do not hold for an arbitrary
+    ``max_fun`` such as a plain ``max``.) Its gradient w.r.t. the scores is
 
     .. math::
 
@@ -144,7 +146,7 @@ def make_fenchel_young_loss(
     must return a SCALAR per core call (consistent with ``"(n)->()"``):
 
     >>> def custom_max(x):
-    ...     return logsumexp(x) + 0.1 * jnp.sum(x ** 2)  # L2-regularized soft-max
+    ...     return logsumexp(x) + 0.1 * jnp.sum(x ** 2)  # logsumexp plus a quadratic term
     >>> structured_loss = braintools.metric.make_fenchel_young_loss(max_fun=custom_max)
 
     See Also
@@ -168,9 +170,10 @@ def make_fenchel_young_loss(
         mf = lambda s: max_fun(s, *args, **kwargs)
         max_fun_last_dim = jnp.vectorize(mf, signature="(n)->()")
         max_value = max_fun_last_dim(scores)
-        # Use an explicit (non-conjugating) inner product over the last
-        # dimension. ``jnp.vdot`` conjugates its first argument, which would be
-        # wrong for complex inputs.
+        # Explicit (non-conjugating) inner product over the last dimension,
+        # matching the real-valued Fenchel-Young definition. ``jnp.vdot`` would
+        # both flatten and conjugate its first argument. Complex inputs are not
+        # specifically supported (the loss is only well-defined for real inputs).
         inner = jnp.sum(targets * scores, axis=-1)
         return max_value - inner
 

--- a/braintools/metric/_firings.py
+++ b/braintools/metric/_firings.py
@@ -154,12 +154,14 @@ def firing_rate(
         spikes at the corresponding time step and neuron.
     width : float or brainunit.Quantity
         Width of the smoothing window. If a float, interpreted as time units
-        consistent with ``dt``. If a brainunit.Quantity, should have time dimensions
-        (e.g., milliseconds). Larger values produce more smoothing.
+        consistent with ``dt`` (assumed **seconds** when both are plain floats,
+        so the rate comes out in Hz). If a brainunit.Quantity, should have time
+        dimensions (e.g., milliseconds). Larger values produce more smoothing.
     dt : float or brainunit.Quantity, optional
         Time step between successive samples in the spike matrix. If None,
         uses the default time step from the brainstate environment
-        (``brainstate.environ.get_dt()``).
+        (``brainstate.environ.get_dt()``). A plain float is assumed to be in
+        seconds.
 
     Returns
     -------
@@ -312,10 +314,11 @@ def victor_purpura_distance(
            temporal coding in visual cortex: a metric-space analysis." 
            Journal of neurophysiology 76.2 (1996): 1310-1326.
     """
-    spikes1 = jnp.asarray(spike_times_1)
-    spikes2 = jnp.asarray(spike_times_2)
+    spikes1 = onp.asarray(u.get_magnitude(spike_times_1), dtype=float)
+    spikes2 = onp.asarray(u.get_magnitude(spike_times_2), dtype=float)
+    cost_factor = float(u.get_magnitude(cost_factor))
 
-    n1, n2 = len(spikes1), len(spikes2)
+    n1, n2 = spikes1.shape[0], spikes2.shape[0]
 
     # Handle empty spike trains
     if n1 == 0:
@@ -323,32 +326,26 @@ def victor_purpura_distance(
     if n2 == 0:
         return float(n1)
 
-    # Dynamic programming matrix
-    # dp[i][j] = minimum cost to transform spikes1[:i] to spikes2[:j]
-    dp = jnp.full((n1 + 1, n2 + 1), jnp.inf)
-
-    # Base cases
-    dp = dp.at[0, 0].set(0.0)
+    # Dynamic programming on host (NumPy) arrays with plain Python arithmetic.
+    # dp[i, j] = minimum cost to transform spikes1[:i] into spikes2[:j].
+    # Using JAX arrays here would force a host<->device round-trip for every
+    # ``.at[].set`` and ``dp[...]`` read, making the routine O(n^2) *device*
+    # operations; NumPy keeps it a fast in-memory fill.
+    dp = onp.empty((n1 + 1, n2 + 1), dtype=float)
+    dp[0, 0] = 0.0
     for i in range(1, n1 + 1):
-        dp = dp.at[i, 0].set(i)  # Delete all spikes in train 1
+        dp[i, 0] = i  # Delete all spikes in train 1
     for j in range(1, n2 + 1):
-        dp = dp.at[0, j].set(j)  # Insert all spikes in train 2
+        dp[0, j] = j  # Insert all spikes in train 2
 
-    # Fill the DP matrix
     for i in range(1, n1 + 1):
+        s1 = spikes1[i - 1]
         for j in range(1, n2 + 1):
-            # Cost to match spike i with spike j (temporal shift)
-            shift_cost = cost_factor * jnp.abs(spikes1[i - 1] - spikes2[j - 1])
-            match_cost = dp[i - 1, j - 1] + shift_cost
-
-            # Cost to delete spike i
+            # Match spike i with spike j (temporal shift), delete, or insert.
+            match_cost = dp[i - 1, j - 1] + cost_factor * abs(s1 - spikes2[j - 1])
             delete_cost = dp[i - 1, j] + 1.0
-
-            # Cost to insert spike j
             insert_cost = dp[i, j - 1] + 1.0
-
-            # Take minimum cost
-            dp = dp.at[i, j].set(jnp.min(jnp.array([match_cost, delete_cost, insert_cost])))
+            dp[i, j] = min(match_cost, delete_cost, insert_cost)
 
     return float(dp[n1, n2])
 
@@ -659,9 +656,11 @@ def burst_synchrony_index(
 
         for j, (neuron2, start2, end2) in enumerate(all_bursts):
             if i != j and neuron1 != neuron2:
-                # Check for temporal overlap
+                # Check for temporal overlap. ``>= 0`` (inclusive) counts bursts
+                # that touch at a single instant -- the strongest possible
+                # synchrony -- which a strict ``> 0`` would wrongly exclude.
                 overlap = min(end1, end2) - max(start1, start2)
-                if overlap > 0:
+                if overlap >= 0:
                     overlapping_neurons.add(neuron2)
 
         # If burst involves multiple neurons, it's synchronous
@@ -675,7 +674,7 @@ def burst_synchrony_index(
 def phase_locking_value(
     spike_matrix: brainstate.typing.ArrayLike,
     reference_freq: float,
-    dt: float = None
+    dt: Union[float, u.Quantity] = None
 ):
     r"""Calculate phase-locking value (PLV) for spike synchronization.
     
@@ -697,8 +696,11 @@ def phase_locking_value(
         Spike matrix with shape ``(n_time_steps, n_neurons)``.
     reference_freq : float
         Reference frequency for phase computation (in Hz).
-    dt : float, optional
-        Time step between successive samples. If None, uses brainstate default.
+    dt : float or brainunit.Quantity, optional
+        Time step between successive samples. If None, uses the brainstate
+        default. A plain float is assumed to be in **seconds** (so that it is
+        consistent with ``reference_freq`` in Hz); a ``brainunit.Quantity`` is
+        converted to seconds.
         
     Returns
     -------
@@ -743,10 +745,16 @@ def phase_locking_value(
         (5,)
     """
     dt = brainstate.environ.get_dt() if dt is None else dt
+    # ``reference_freq`` is in Hz, so the time base must be in seconds. A
+    # ``brainunit.Quantity`` ``dt`` (e.g. the ``brainstate.environ.get_dt()``
+    # default, or ``0.1 * u.ms``) is converted to seconds; a plain float is
+    # assumed to already be in seconds.
+    if isinstance(dt, u.Quantity):
+        dt = float(dt.to_decimal(u.second))
     spikes = jnp.asarray(spike_matrix)
     n_time, n_neurons = spikes.shape
 
-    # Create time vector
+    # Create time vector (in seconds)
     times = jnp.arange(n_time) * dt
 
     # Reference phase signal
@@ -968,6 +976,8 @@ def correlation_index(
 
     # Bin size in samples (``window_size`` and ``dt`` must share a time unit).
     bin_size = max(1, int(u.get_magnitude(window_size) / u.get_magnitude(dt)))
+    # Only whole bins are used; any trailing samples that do not fill a complete
+    # bin are discarded so every bin has the same width.
     n_bins = n_time // bin_size
 
     if n_bins < 2:
@@ -977,7 +987,7 @@ def correlation_index(
     binned_spikes = jnp.zeros((n_bins, n_neurons))
     for i in range(n_bins):
         start_idx = i * bin_size
-        end_idx = min((i + 1) * bin_size, n_time)
+        end_idx = (i + 1) * bin_size
         binned_spikes = binned_spikes.at[i, :].set(jnp.sum(spikes[start_idx:end_idx, :], axis=0))
 
     # Calculate pairwise correlations
@@ -1000,4 +1010,6 @@ def correlation_index(
 
             correlations.append(corr)
 
-    return float(jnp.mean(jnp.array(correlations)))
+    # Clamp to the documented [-1, 1] range (guards against float round-off in
+    # ``corrcoef`` pushing the mean marginally outside the interval).
+    return float(jnp.clip(jnp.mean(jnp.array(correlations)), -1.0, 1.0))

--- a/braintools/metric/_lfp.py
+++ b/braintools/metric/_lfp.py
@@ -58,8 +58,15 @@ def _analytic_band(fft_vals: jax.Array, freqs: jax.Array, low: float, high: floa
     ``abs`` is the amplitude envelope. The earlier symmetric ``|f|`` mask produced an
     almost-real band-passed signal whose phase was degenerate (≈ 0 or π).
     """
-    mask = (freqs >= low) & (freqs <= high)  # positive frequencies only
-    band = jnp.where(mask, fft_vals, 0.0 + 0.0j) * 2.0
+    # Broadcast the per-frequency mask/factor against the frequency axis (axis 0),
+    # supporting both 1-D and (n_time, ...) inputs.
+    shape = (-1,) + (1,) * (fft_vals.ndim - 1)
+    mask = ((freqs >= low) & (freqs <= high)).reshape(shape)
+    # Double only strictly positive in-band bins. DC (f == 0) must NOT be doubled
+    # in the analytic-signal construction; doubling it distorts the phase of any
+    # band that includes 0 Hz.
+    factor = jnp.where(freqs == 0.0, 1.0, 2.0).reshape(shape)
+    band = jnp.where(mask, fft_vals * factor, 0.0 + 0.0j)
     return jnp.fft.ifft(band, axis=0)
 
 
@@ -288,6 +295,10 @@ def power_spectral_density(
     -----
     Supplying ``freq_range`` uses boolean-mask indexing (data-dependent output
     length), so that path is not ``jit``-compatible; the full-spectrum path is.
+
+    The window is ``jnp.hanning``, which is the *symmetric* Hann window;
+    ``scipy.signal.welch`` uses a *periodic* (``sym=False``) Hann window by
+    default, so PSD values differ marginally when comparing against scipy.
     """
     dt = _to_seconds(dt)
     lfp = jnp.asarray(u.get_magnitude(lfp))
@@ -399,7 +410,11 @@ def coherence_analysis(
     p12 = jnp.mean(f1 * jnp.conj(f2), axis=0)
     p11 = jnp.mean(jnp.abs(f1) ** 2, axis=0)
     p22 = jnp.mean(jnp.abs(f2) ** 2, axis=0)
-    coherence = jnp.abs(p12) ** 2 / (p11 * p22 + 1e-15)
+    # Scale-invariant guard: bins with zero power (denominator 0) yield 0 (their
+    # cross-power is also 0). Avoids the absolute ``+ 1e-15`` floor, which biased
+    # genuinely-coherent bins toward 0 for amplitude-downscaled signals.
+    denom = p11 * p22
+    coherence = jnp.abs(p12) ** 2 / jnp.where(denom > 0, denom, 1.0)
     coherence = jnp.clip(coherence, 0.0, 1.0)
 
     freqs = jnp.fft.rfftfreq(nperseg, dt)
@@ -407,6 +422,11 @@ def coherence_analysis(
         mask = (freqs >= freq_range[0]) & (freqs <= freq_range[1])
         freqs = freqs[mask]
         coherence = coherence[mask]
+        # Mirror power_spectral_density: never return empty arrays for an
+        # out-of-range band.
+        if freqs.size == 0:
+            freqs = jnp.array([freq_range[0]])
+            coherence = jnp.zeros((1,))
     return freqs, coherence
 
 
@@ -637,6 +657,14 @@ def lfp_phase_coherence(
     phase_coherence_matrix : jax.Array
         Symmetric coherence matrix with shape ``(n_channels, n_channels)`` and
         values in ``[0, 1]`` (diagonal exactly 1).
+
+    Notes
+    -----
+    The phase of a channel that carries negligible power in ``freq_band`` is
+    undefined. Such channels are detected (in-band power negligible relative to
+    their broadband power) and their off-diagonal coherence is reported as ``0``
+    rather than a spurious value (a zero band-limited signal would otherwise
+    appear perfectly phase-locked).
     """
     dt = _to_seconds(dt)
     lfp_signals = jnp.asarray(u.get_magnitude(lfp_signals))
@@ -660,6 +688,17 @@ def lfp_phase_coherence(
     # mathematically bounded in [0, 1]. Clip to remove float32 roundoff that
     # can push near-coherent pairs marginally above 1.0.
     coherence = jnp.clip(coherence, 0.0, 1.0)
+
+    # A channel with negligible power in ``freq_band`` has a degenerate (~0)
+    # analytic signal whose phase is undefined -- ``angle(0) == 0`` would make
+    # every such channel look perfectly phase-locked. Detect those channels
+    # (in-band power negligible relative to broadband power) and report their
+    # off-diagonal coherence as 0 instead of a spurious value.
+    in_band_power = jnp.mean(jnp.abs(analytic) ** 2, axis=0)      # (n_channels,)
+    total_power = jnp.mean(lfp_signals ** 2, axis=0)              # (n_channels,)
+    valid = in_band_power > 1e-6 * jnp.maximum(total_power, 1e-30)
+    coherence = jnp.where(valid[:, None] & valid[None, :], coherence, 0.0)
+
     # A channel is perfectly phase-locked with itself, so the diagonal is
     # exactly 1 by definition; set it explicitly to remove float32 drift that
     # can leave it marginally below 1.0.

--- a/braintools/metric/_lfp_test.py
+++ b/braintools/metric/_lfp_test.py
@@ -369,14 +369,18 @@ class TestLFPPhaseCoherence(unittest.TestCase):
         signal = jnp.sin(2 * jnp.pi * 25 * t)  # 25 Hz signal
         signals = jnp.column_stack([signal, signal])
 
-        # Test in beta band (should have high coherence)
+        # The 25 Hz tone lives in the beta band, so coherence there is genuine
+        # and high.
         coherence_beta = lfp_phase_coherence(signals, dt, freq_band=(20, 30))
-        # Test in alpha band (should have lower coherence)
+        # The alpha band carries no signal power; phase in an empty band is
+        # undefined, so the LFP-1 fix reports ~0 instead of a spurious high
+        # value (the previous expectation of >= 0.8 here was the bug).
         coherence_alpha = lfp_phase_coherence(signals, dt, freq_band=(8, 12))
 
-        # Both should be high for identical signals, just check they're valid
         self.assertGreaterEqual(coherence_beta[0, 1], 0.8)
-        self.assertGreaterEqual(coherence_alpha[0, 1], 0.8)
+        self.assertLessEqual(coherence_alpha[0, 1], 0.2)
+        # All coherence values stay within the valid [0, 1] range.
+        self.assertGreaterEqual(coherence_alpha[0, 1], 0.0)
 
 
 class TestLFPRegressionAndFeatures(unittest.TestCase):

--- a/braintools/metric/_pairwise.py
+++ b/braintools/metric/_pairwise.py
@@ -36,7 +36,7 @@ def _safe_row_norm(a: jax.Array) -> jax.Array:
     double-``where`` construction below returns a norm of ``0`` for zero rows
     while keeping the gradient finite.
     """
-    sq = jnp.sum(a * a, axis=1, keepdims=True)
+    sq = jnp.sum(a * a, axis=-1, keepdims=True)
     is_zero = sq == 0.0
     safe_sq = jnp.where(is_zero, 1.0, sq)
     return jnp.where(is_zero, 0.0, jnp.sqrt(safe_sq))
@@ -78,8 +78,10 @@ def pairwise_cosine_similarity(
         Input array with shape ``(n_samples_Y, n_features)``. If ``None``,
         computes pairwise similarities within ``X``.
     eps : float, default=1e-8
-        Lower bound applied to the product of norms to avoid division by zero.
-        Pairs that involve a zero vector therefore yield a similarity of ``0``.
+        Lower bound applied to **each row norm** (not their product) to avoid
+        division by zero. Only norms below ``eps`` are affected, so similarities
+        between small but non-zero vectors are computed exactly; pairs that
+        involve a zero vector still yield a similarity of ``0``.
 
     Returns
     -------
@@ -99,10 +101,12 @@ def pairwise_cosine_similarity(
 
     Notes
     -----
-    The denominator is floored at ``eps`` (rather than having ``eps`` added to
-    it), so that the value **and** the gradient remain finite for zero vectors,
-    and non-zero vectors are unaffected. This avoids the NaN-gradient hazard of
-    the naive ``dot / (norm_product + eps)`` formulation.
+    Each row norm is floored at ``eps`` (rather than adding ``eps`` to the norm
+    product), so that the value **and** the gradient remain finite for zero
+    vectors while non-zero vectors -- including very small ones -- are
+    unaffected. This avoids both the NaN-gradient hazard of the naive
+    ``dot / (norm_product + eps)`` formulation and the magnitude-coupling bug of
+    flooring the *product* of the two norms.
 
     Examples
     --------
@@ -115,7 +119,7 @@ def pairwise_cosine_similarity(
         >>> print(sim_matrix)
         [[1.         0.         0.70710677]
          [0.         1.         0.70710677]
-         [0.70710677 0.70710677 1.        ]]
+         [0.70710677 0.70710677 1.0000001 ]]
 
         >>> Y = jnp.array([[1., 1., 1.], [0., 0., 1.]])
         >>> braintools.metric.pairwise_cosine_similarity(X, Y).shape
@@ -131,13 +135,16 @@ def pairwise_cosine_similarity(
     # Pairwise dot products: shape (n_samples_X, n_samples_Y)
     dot_products = X @ Y.T
 
-    # L2 norms for each sample (gradient-safe at zero vectors).
-    X_norms = _safe_row_norm(X)
-    Y_norms = _safe_row_norm(Y)
+    # L2 norms for each sample (gradient-safe at zero vectors). Floor *each row
+    # norm* at ``eps`` rather than their product: this engages only for genuine
+    # near-zero vectors, so the (scale-invariant) cosine stays correct for small
+    # but non-zero vectors, while the value and gradient remain finite at the
+    # origin (a zero row contributes a zero numerator, hence a similarity of 0).
+    X_norms = jnp.maximum(_safe_row_norm(X), eps)
+    Y_norms = jnp.maximum(_safe_row_norm(Y), eps)
     norm_products = X_norms @ Y_norms.T
 
-    # Floor the denominator (keeps value and gradient finite for zero vectors).
-    return dot_products / jnp.maximum(norm_products, eps)
+    return dot_products / norm_products
 
 
 @set_module_as('braintools.metric')
@@ -160,8 +167,8 @@ def pairwise_cosine_distance(
         Input array with shape ``(n_samples_Y, n_features)``. If ``None``,
         computes pairwise distances within ``X``.
     eps : float, default=1e-8
-        Lower bound applied to the product of norms to avoid division by zero.
-        Pairs involving a zero vector therefore yield a distance of ``1``.
+        Lower bound applied to each row norm to avoid division by zero. Pairs
+        involving a zero vector therefore yield a distance of ``1``.
 
     Returns
     -------

--- a/braintools/metric/_ranking.py
+++ b/braintools/metric/_ranking.py
@@ -24,6 +24,7 @@ leading dimensions are considered batch dimensions.
 
 Standalone usage:
 
+>>> import jax.numpy as jnp
 >>> import braintools as braintools
 >>> scores = jnp.array([2., 1., 3.])
 >>> labels = jnp.array([1., 0., 0.])
@@ -279,6 +280,7 @@ def ranking_softmax_loss(
     >>> labels = jnp.array([1.0, 0.0, 2.0])
     >>> loss = braintools.metric.ranking_softmax_loss(logits, labels)
     >>> print(f"Loss: {loss:.4f}")
+    Loss: 2.2228
 
     Batch processing with masking:
 
@@ -289,12 +291,14 @@ def ranking_softmax_loss(
     >>> where = jnp.array([[True, True, False], [True, True, True]])
     >>> loss = braintools.metric.ranking_softmax_loss(logits, labels, where=where)
     >>> print(f"Batch loss: {loss:.4f}")
+    Batch loss: 0.4968
 
     Per-item weighting:
 
     >>> weights = jnp.array([1.0, 2.0, 1.0])  # Emphasize middle item
     >>> loss = braintools.metric.ranking_softmax_loss(logits[0], labels[0], weights=weights)
     >>> print(f"Weighted loss: {loss:.4f}")
+    Weighted loss: 0.4076
 
     Unreduced losses for analysis (legacy ``reduce_fn`` API):
 
@@ -302,6 +306,7 @@ def ranking_softmax_loss(
     ...     logits, labels, where=where, reduce_fn=None
     ... )
     >>> print(f"Individual losses: {batch_losses}")
+    Individual losses: [0.31326163 0.68026966]
 
     Using the ``reduction`` string API (preferred):
 

--- a/braintools/metric/_regression.py
+++ b/braintools/metric/_regression.py
@@ -31,10 +31,12 @@ __all__ = [
     'l1_loss',
     'l2_loss',
     'l2_norm',
+    'safe_norm',
     'huber_loss',
     'log_cosh',
     'cosine_similarity',
     'cosine_distance',
+    'L1Loss',
 ]
 
 
@@ -122,7 +124,7 @@ def safe_norm(x: brainstate.typing.ArrayLike,
         >>> X = jnp.array([[1.0, 2.0], [3.0, 4.0]])
         >>> # L2 norm along rows
         >>> safe_norm(X, min_norm=0.1, axis=1)
-        Array([2.2360680, 5.       ], dtype=float32)
+        Array([2.236068, 5.      ], dtype=float32)
 
     See Also
     --------
@@ -172,8 +174,9 @@ def squared_error(
         to be zeros, making this equivalent to computing the squared magnitude
         of predictions.
     axis : int or tuple of ints, optional
-        Axis or axes along which to reduce the error. If None, no reduction
-        is performed and element-wise errors are returned.
+        Axis or axes along which to reduce when ``reduction`` is ``'mean'`` or
+        ``'sum'``. Has no effect when ``reduction='none'`` (the default), in
+        which case element-wise errors are always returned.
     reduction : {'none', 'mean', 'sum'}, default='none'
         Reduction operation to apply:
         
@@ -528,7 +531,10 @@ def l1_loss(logits: brainstate.typing.ArrayLike,
         Array([0.5, 1. ], dtype=float32)
     """
 
-    diff = (logits - targets).reshape((logits.shape[0], -1))
+    # ``atleast_1d`` lets a 0-d/scalar input be treated as a single-sample batch
+    # instead of raising ``IndexError`` on ``shape[0]``.
+    diff = jnp.atleast_1d(jnp.asarray(logits) - jnp.asarray(targets))
+    diff = diff.reshape((diff.shape[0], -1))
     per_sample_mae = jnp.mean(jnp.abs(diff), axis=-1)
     return _reduce(outputs=per_sample_mae, reduction=reduction)
 
@@ -737,7 +743,7 @@ def huber_loss(
         >>> predictions = jnp.array([1.0, 2.0, 5.0])
         >>> targets = jnp.array([1.1, 1.9, 3.0])  # Last prediction is outlier
         >>> braintools.metric.huber_loss(predictions, targets)
-        Array([0.00499997, 0.00499998, 1.5       ], dtype=float32)
+        Array([0.005, 0.005, 1.5  ], dtype=float32)
 
     Reduce to a scalar mean:
 
@@ -791,8 +797,9 @@ def log_cosh(
     predictions : brainstate.typing.ArrayLike
         A vector of arbitrary shape ``[...]``.
     targets : brainstate.typing.ArrayLike, optional
-        A vector with the same shape as ``predictions`` (no broadcasting). If
-        not provided then it is assumed to be a vector of zeros.
+        A vector with a shape broadcastable to ``predictions``. If not provided
+        then it is assumed to be a vector of zeros. Inputs must be dimensionless
+        (``log(cosh(x))`` is only defined for a dimensionless argument).
     axis : int or tuple of ints, optional
         Axis or axes along which to reduce when ``reduction`` is ``'mean'`` or
         ``'sum'``. If None, reduction (if any) is over all elements.
@@ -833,7 +840,7 @@ def log_cosh(
         >>> import braintools
         >>> predictions = jnp.array([0.0, 1.0, -1.0])
         >>> braintools.metric.log_cosh(predictions)
-        Array([0.        , 0.43378806, 0.43378806], dtype=float32)
+        Array([0.       , 0.4337808, 0.4337808], dtype=float32)
     """
     assert u.math.is_float(predictions), 'predictions must be float.'
     errors = (predictions - targets) if (targets is not None) else predictions
@@ -908,7 +915,9 @@ def cosine_similarity(
 
     The function handles zero vectors gracefully using the ``epsilon`` parameter
     to floor the denominator, which keeps both the value and the gradient finite
-    for zero-vector inputs.
+    for zero-vector inputs. Note that because each vector is normalized
+    independently, the gradient -- while finite -- can be large in magnitude for
+    near-zero inputs (it scales like ``1 / epsilon``).
 
     Examples
     --------
@@ -922,7 +931,7 @@ def cosine_similarity(
         >>> pred = jnp.array([1.0, 2.0, 3.0])
         >>> target = jnp.array([2.0, 4.0, 6.0])
         >>> braintools.metric.cosine_similarity(pred, target)
-        Array(1., dtype=float32)
+        Array(0.9999999, dtype=float32)
 
     Batch computation (all orthogonal pairs):
 

--- a/braintools/metric/_smoothing.py
+++ b/braintools/metric/_smoothing.py
@@ -17,6 +17,7 @@
 
 import brainstate
 import brainunit as u
+import jax
 import jax.numpy as jnp
 
 from braintools._misc import set_module_as
@@ -28,7 +29,7 @@ __all__ = ['smooth_labels']
 def smooth_labels(
     labels: brainstate.typing.ArrayLike,
     alpha: float,
-) -> jnp.ndarray:
+) -> jax.Array:
     r"""Apply label smoothing regularization to one-hot encoded labels.
 
     Label smoothing is a regularization technique that prevents neural networks
@@ -73,6 +74,8 @@ def smooth_labels(
 
     Raises
     ------
+    TypeError
+        If ``labels`` is not a floating-point array.
     ValueError
         If ``alpha`` is outside the closed interval ``[0, 1]``.
 
@@ -152,7 +155,8 @@ def smooth_labels(
     .. [3] Pereyra, Gabriel, et al. "Regularizing neural networks by penalizing 
            confident output distributions." arXiv preprint arXiv:1701.06548 (2017).
     """
-    assert u.math.is_float(labels), f'labels should be of float type.'
+    if not u.math.is_float(labels):
+        raise TypeError('labels should be of float type.')
     if not (0.0 <= alpha <= 1.0):
         raise ValueError(f'alpha must be in the range [0, 1], but got {alpha}.')
     num_categories = labels.shape[-1]

--- a/braintools/metric/_smoothing_test.py
+++ b/braintools/metric/_smoothing_test.py
@@ -45,7 +45,9 @@ class SmoothLabelsTest(parameterized.TestCase):
         np.testing.assert_allclose(braintools.metric.smooth_labels(self.ts, 1.), self.exp_alpha_one, atol=1e-4)
 
     def test_smooth_labels_assertion_error(self):
-        with self.assertRaises(AssertionError):
+        # Integer labels are rejected with an explicit ``TypeError`` (a real
+        # exception that survives ``python -O``, unlike a bare ``assert``).
+        with self.assertRaises(TypeError):
             braintools.metric.smooth_labels(jnp.array([[1, 0, 0], [0, 1, 0]]), 0.1)
 
     def test_alpha_very_small_positive(self):

--- a/braintools/metric/_util.py
+++ b/braintools/metric/_util.py
@@ -15,6 +15,9 @@
 
 
 def _reduce(outputs, reduction, axis=None):
+    # Note: ``axis`` only takes effect for the ``'mean'``/``'sum'`` reductions;
+    # with ``reduction='none'`` the input is returned unchanged and ``axis`` is
+    # ignored.
     if reduction == 'mean':
         return outputs.mean(axis)
     elif reduction == 'sum':

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,40 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Project-wide pytest configuration.
+
+Force a non-interactive ("Agg") matplotlib backend for the whole test suite so
+that running the tests never opens GUI image windows and works in headless / CI
+environments. ``conftest.py`` is imported by pytest before any test module, so
+this takes effect even for modules that import ``matplotlib.pyplot`` lazily.
+
+We set ``MPLBACKEND`` *before* importing matplotlib: that environment variable is
+read at matplotlib import time and cannot be silently overridden by an
+interactive default, making it the most robust way to guarantee a headless
+backend regardless of which test module imports matplotlib first. The explicit
+``matplotlib.use("Agg")`` call is belt-and-suspenders for an already-imported
+matplotlib.
+"""
+
+import os
+
+os.environ["MPLBACKEND"] = "Agg"
+
+try:
+    import matplotlib
+
+    matplotlib.use("Agg", force=True)
+except ImportError:  # matplotlib is optional; nothing to configure without it.
+    pass

--- a/docs/braintools-metric-issues-found-20260619.md
+++ b/docs/braintools-metric-issues-found-20260619.md
@@ -1,0 +1,276 @@
+# `braintools.metric` — Issues Found and Proposed Solutions (2026‑06‑19)
+
+A senior‑developer / JAX‑expert audit of every source file in `braintools/metric/`
+(`_classification.py`, `_regression.py`, `_firings.py`, `_lfp.py`, `_correlation.py`,
+`_ranking.py`, `_fenchel_young.py`, `_pairwise.py`, `_smoothing.py`, `_util.py`,
+`__init__.py`) and their docstrings.
+
+Methodology: each file was read in full and inspected for correctness, JAX pitfalls
+(NaN gradients, tracer control flow, dtype), numerical stability, edge cases,
+`brainunit.Quantity` handling, API consistency, and NumPy‑doc accuracy. **Every
+actionable finding below was reproduced with a runnable snippet** before being
+recorded. Baseline test state: **332 passing**.
+
+The module is in good shape overall — the core mathematics of every metric was
+verified correct against references. The defects are concentrated in (a) a few
+`brainunit.Quantity`/edge‑case crashes, (b) one numerically wrong result for
+small vectors, (c) one inverted docstring interpretation, and (d) a batch of
+docstring example outputs that would fail a strict doctest.
+
+Legend — Severity: **High** (crash / wrong result for normal use), **Medium**
+(crash on a supported input class / robustness), **Low** (edge case / docs).
+
+---
+
+## Summary table
+
+| ID | File | Sev | Category | One‑line |
+|----|------|-----|----------|----------|
+| FIR‑1 | `_firings.py` | High | brainunit | `phase_locking_value` crashes on `Quantity` `dt` (incl. the common `environ.get_dt()` default) |
+| INIT‑1 | `__init__.py` / `_regression.py` | High | api | `L1Loss` (documented public class) is unexported → `from braintools.metric import L1Loss` raises `ImportError` |
+| PW‑1 | `_pairwise.py` | High | numerical | `pairwise_cosine_similarity` returns wrong values for small (non‑zero) vectors |
+| COR‑1 | `_correlation.py` | High | docs | `voltage_fluctuation` Returns interpretation is inverted/impossible |
+| COR‑2 | `_correlation.py` | Medium | brainunit | `cross_correlation` crashes on `Quantity` input |
+| LFP‑1 | `_lfp.py` | Medium | edge‑case | `lfp_phase_coherence` reports spurious coherence for an empty/zero‑power band |
+| SM‑1 | `_smoothing.py` | Medium | edge‑case | `smooth_labels` uses `assert` for input validation (stripped under `python -O`) |
+| FIR‑2 | `_firings.py` | Medium | jax/perf | `victor_purpura_distance` builds its DP table with traced JAX arrays → O(n²) device round‑trips |
+| REG‑6 | `_regression.py` | Low | edge‑case | `l1_loss` raises `IndexError` on a 0‑d/scalar input |
+| LFP‑2 | `_lfp.py` | Low | api | `coherence_analysis` lacks the empty‑`freq_range` fallback that `power_spectral_density` has |
+| LFP‑3 | `_lfp.py` | Low | numerical | `coherence_analysis` uses an absolute `1e‑15` floor (amplitude‑dependent) |
+| LFP‑5 | `_lfp.py` | Low | numerical | `_analytic_band` doubles the DC bin if a band includes 0 Hz |
+| CLS‑2 | `_classification.py` | Low | api | `sigmoid_binary_cross_entropy` raises `AttributeError` for list inputs |
+| FIR‑3 | `_firings.py` | Low | correctness | `burst_synchrony_index` strict `> 0` overlap excludes endpoint‑touching bursts |
+| FIR‑4 | `_firings.py` | Low | correctness | `correlation_index` silently drops the trailing partial bin; dead clamp code |
+| FIR‑6 | `_firings.py` | Low | numerical | `correlation_index` result not clamped to documented `[-1, 1]` |
+| COR‑4 | `_correlation.py` | Low | jax | `cross_correlation` `lax.cond` returns a weak‑typed Python `0.` branch |
+| PW‑3 | `_pairwise.py` | Low | jax | `_safe_row_norm` hardcodes `axis=1` |
+| CLS‑1 | `_classification.py` | Low | docs | `multiclass_hinge_loss` example output wrong (`[0. 0.]` → `[0. 0.6]`) |
+| REG‑1..4 | `_regression.py` | Low | docs | `huber_loss`/`log_cosh`/`cosine_similarity`/`safe_norm` example outputs wrong |
+| PW‑2 | `_pairwise.py` | Low | docs | `pairwise_cosine_similarity` example diagonal wrong (`1.` → `1.0000001`) |
+| REG‑5 | `_regression.py` | Low | docs | `log_cosh` says "no broadcasting" but it does broadcast |
+| REG‑7 | `_regression.py` | Low | docs | `log_cosh` rejects `Quantity`; should document dimensionless requirement |
+| REG‑9 | `_regression.py` | Low | docs | `squared_error` `axis` param wording implies it works without a reduction |
+| FIR‑7 | `_firings.py` | Low | api/docs | `phase_locking_value` `dt` type hint/doc omits `Quantity` and the Hz/seconds contract |
+| FIR‑8 | `_firings.py` | Low | docs | `firing_rate` does not state the float‑seconds assumption in Parameters |
+| FY‑1..3 | `_fenchel_young.py` | Low | docs | unconditional "non‑negative" claim; misleading complex/`L2` comments |
+| COR‑3 | `_correlation.py` | Low | docs | `weighted_correlation`/`functional_connectivity_dynamics` examples not doctestable |
+| RNK‑2 | `_ranking.py` | Low | docs | `ranking_softmax_loss` examples print via f‑string with no expected output; module example omits `import jnp` |
+| LFP‑4 | `_lfp.py` | Low | docs | PSD "Hann‑windowed" differs from scipy's periodic default (note) |
+| SM‑2 | `_smoothing.py` | Low | api | `smooth_labels` return annotation is legacy `jnp.ndarray` |
+| UTIL‑1 | `_util.py` | Low | api | `_reduce` silently ignores `axis` when `reduction='none'` (note) |
+| CLS‑4 | `_classification.py` | Low | numerical | `sigmoid_focal_loss` has non‑finite gradient for `0<gamma<1` with saturated logits (note) |
+| CLS‑3 / CLS‑5 / REG‑8 / RNK‑1 / LFP‑6 | various | Low | note | Acceptable behaviors documented for clarity (no behavior change) |
+
+---
+
+## High severity
+
+### FIR‑1 — `phase_locking_value` crashes on `Quantity` `dt`
+**Location:** `_firings.py:745‑753`.
+**Evidence:**
+```python
+m.phase_locking_value(spikes, 10.0, dt=0.1*u.ms)
+# TypeError: exp requires ndarray or scalar arguments, got <class 'saiunit.Quantity'>
+```
+`times = jnp.arange(n_time) * dt` keeps units when `dt` is a `Quantity`, so
+`jnp.exp(1j * spike_phases)` fails. This is the *common* path because
+`brainstate.environ.get_dt()` returns a `Quantity`. A second latent issue: with
+`reference_freq` in Hz, the time base must be **seconds**, but a `0.1*u.ms`
+magnitude would be off by 1000×.
+**Solution:** convert `dt` to **seconds** (`dt.to_decimal(u.second)` for a
+`Quantity`, otherwise assume seconds), document the Hz/seconds contract, and
+widen the `dt` type hint (see FIR‑7). Add a regression test with a `Quantity` `dt`.
+
+### PW‑1 — `pairwise_cosine_similarity` wrong for small non‑zero vectors
+**Location:** `_pairwise.py:140`.
+**Evidence:**
+```python
+X = jnp.array([[3e-5, 0.], [3e-5, 0.]])
+m.pairwise_cosine_similarity(X)[0,0]   # 0.09   (true cosine = 1.0)
+```
+The denominator floors the **product** of the two norms at `eps=1e‑8`. Whenever
+`‖x‖·‖y‖ < 1e‑8` — which happens for perfectly legitimate small vectors — the
+floor inflates the denominator and corrupts the (scale‑invariant) cosine. The
+floor should apply to each *row* norm individually, which only engages for genuine
+near‑zero vectors.
+**Solution:** clamp `X_norms`/`Y_norms` at `eps` *before* the outer product:
+`norm_products = jnp.maximum(X_norms, eps) @ jnp.maximum(Y_norms, eps).T`. This
+preserves the documented zero‑vector → `0` behaviour (a zero row still has dot‑product
+`0` in the numerator) and the gradient safety of `_safe_row_norm`. Update the Notes
+and `eps` description accordingly.
+
+### INIT‑1 — public class `L1Loss` is not exported
+**Location:** `_regression.py` (`__all__`), `__init__.py` (import block + `__all__`).
+**Evidence:**
+```python
+from braintools.metric import L1Loss
+# ImportError: cannot import name 'L1Loss' from 'braintools.metric'
+```
+`L1Loss` is a fully‑documented public class (NumPy‑doc docstring, `Examples` showing
+`from braintools.metric import L1Loss`), but it was absent from `_regression.__all__`,
+from the `from ._regression import (...)` block in `__init__.py`, and from
+`braintools.metric.__all__`. Its own example was therefore non‑importable, and
+`braintools.metric.L1Loss` did not exist. (Discovered by a `--doctest-modules` sweep;
+`MaxFun` in `_fenchel_young.py` is a typing `Protocol`, intentionally internal, and is
+the only other unexported public‑cased class.)
+**Solution:** add `'L1Loss'` to `_regression.__all__`, import it in the `_regression`
+block of `__init__.py`, and add `'L1Loss'` to `braintools.metric.__all__`. Verified
+`from braintools.metric import L1Loss` and `L1Loss().update(x, y)` now work.
+
+### COR‑1 — `voltage_fluctuation` documented interpretation is inverted
+**Location:** `_correlation.py:213‑218` (Returns) and the misleading comments in
+`_correlation_test.py:147,156`.
+**Evidence:** the Golomb χ²(N) = σ²_V / ⟨σ²_Vᵢ⟩ is bounded in approximately
+`[1/N, 1]`: it → 1 for full synchrony and → 1/N for asynchrony, and **cannot exceed 1**.
+```python
+voltage_fluctuation(sync_signal)  # 0.9998   (≈1  → synchronous)
+voltage_fluctuation(async_signal) # 0.0168   (≈1/N → asynchronous)
+```
+The docstring says "Values > 1 indicate synchronized activity, values ≈ 1 indicate
+asynchronous activity" — both halves are wrong (the `>1` region is unreachable, and
+`≈1` is synchrony, not asynchrony).
+**Solution:** rewrite Returns to: *index in approximately `[1/N, 1]`; values near 1
+indicate strong synchrony, values near 1/N indicate asynchronous activity; a constant
+population returns 1.0 by convention.* Fix the two test comments.
+
+---
+
+## Medium severity
+
+### COR‑2 — `cross_correlation` crashes on `Quantity` input
+**Location:** `_correlation.py:117‑130`.
+**Evidence:** `cross_correlation(spikes * u.UNITLESS, 5.0, dt=1.0)` →
+`TypeError: sum requires ndarray ...`. Every sibling metric strips units with
+`u.get_magnitude(...)`; this one operates on the raw input.
+**Solution:** `spikes = jnp.asarray(u.get_magnitude(spikes))` at the top.
+
+### LFP‑1 — `lfp_phase_coherence` spurious coherence for empty bands
+**Location:** `_lfp.py:650‑667`.
+**Evidence:** for a band containing no signal power the band‑limited analytic signal
+is ≈ 0; `jnp.angle(0) == 0` makes all unit phasors identical, so channels appear
+phase‑locked:
+```python
+lfp_phase_coherence(sig_10_and_30Hz, 0.001, freq_band=(200,300))[0,1]  # 0.31 (should be ~0)
+```
+**Solution:** detect channels whose in‑band power is negligible relative to their
+broadband power and report their off‑diagonal coherence as `0` (the phase of a
+zero signal is undefined). This keeps the documented unit‑phasor PLV unchanged for
+channels with real in‑band power. Document the behaviour.
+**Test impact:** the pre‑existing `TestLFPPhaseCoherence.test_different_frequency_bands`
+asserted `coherence_alpha >= 0.8` for a pure 25 Hz signal evaluated in the 8–12 Hz
+band — i.e. it *encoded the spurious‑coherence bug*. Updated it to assert the corrected
+semantics (empty band → ~0; the in‑band beta result stays ≥ 0.8).
+
+### SM‑1 — `smooth_labels` validates with `assert`
+**Location:** `_smoothing.py:155`.
+**Evidence:** under `python -O`, `assert` is stripped and integer labels pass
+silently. `assert` is an anti‑pattern for input validation (the sibling `alpha`
+check correctly raises `ValueError`).
+**Solution:** `if not u.math.is_float(labels): raise TypeError(...)`; update
+`test_smooth_labels_assertion_error` to expect `TypeError`.
+
+### FIR‑2 — `victor_purpura_distance` DP uses traced JAX arrays
+**Location:** `_firings.py:328‑353`.
+**Evidence:** the DP table is a `jnp` array mutated with `.at[i,j].set(...)` and read
+with `dp[i-1,j-1]` inside a Python double loop, forcing a device round‑trip per cell
+(~1.9 s for a 40×40 pair). The result is correct but pathologically slow. The function
+is documented host‑only.
+**Solution:** build the DP table with NumPy (`numpy` floats / `min`), converting the
+spike times once. Functionally identical, orders of magnitude faster.
+
+---
+
+## Low severity — behaviour fixes
+
+- **REG‑6** `_regression.py:531` — `l1_loss(jnp.array(1.0), jnp.array(1.5))` →
+  `IndexError` from `logits.shape[0]`. Fix: `jnp.atleast_1d` the difference before
+  the `(N, -1)` reshape so scalars are treated as a one‑sample batch.
+- **LFP‑2** `_lfp.py:406‑410` — `coherence_analysis` returns empty arrays for an
+  out‑of‑range `freq_range`; mirror the PSD fallback (one zero bin).
+- **LFP‑3** `_lfp.py:402` — replace the absolute `+ 1e‑15` denominator floor with a
+  scale‑invariant `jnp.where(denom > 0, denom, 1.0)` guard so down‑scaled signals
+  are not biased.
+- **LFP‑5** `_lfp.py:61‑62` — the analytic‑signal reconstruction doubles every in‑band
+  bin including DC; DC (and Nyquist) must not be doubled. Use a per‑bin factor that is
+  `1` at `f == 0` and `2` otherwise.
+- **CLS‑2** `_classification.py:113` — `sigmoid_binary_cross_entropy` calls `.astype`
+  on raw inputs; `jnp.asarray` both arguments first (matches `nll_loss`).
+- **FIR‑3** `_firings.py:664` — change `overlap > 0` to `overlap >= 0` so bursts that
+  touch at a single instant (the strongest synchrony) are counted; document the convention.
+- **FIR‑4 / FIR‑6** `_firings.py:980,999,1003` — remove the dead `min(...)` clamp,
+  document that the trailing partial bin is discarded, and clamp the returned mean to
+  the documented `[-1, 1]`.
+- **COR‑4** `_correlation.py:137,148` — return `jnp.zeros((), dtype=sqrt_ij.dtype)`
+  from the `lax.cond` zero branch instead of a weak‑typed Python `0.`.
+- **PW‑3** `_pairwise.py:39` — use `axis=-1` in `_safe_row_norm` for robustness.
+
+## Low severity — documentation fixes
+
+- **CLS‑1** `_classification.py:366` — example prints `[0.  0. ]`; actual is
+  `[0.         0.5999999]`.
+- **REG‑1** `_regression.py:739` — `huber_loss` example `0.00499997` → `0.005`.
+- **REG‑2** `_regression.py:836` — `log_cosh` example `0.43378806` → `0.4337808`.
+- **REG‑3** `_regression.py:925` — `cosine_similarity` example `1.` → `0.9999999`.
+- **REG‑4** `_regression.py:125` — `safe_norm` example `2.2360680` (invalid repr) →
+  `2.236068`.
+- **PW‑2** `_pairwise.py:118` — diagonal `1.` → `1.0000001`.
+- **REG‑5** `_regression.py:794` — `log_cosh` "no broadcasting" → "broadcastable".
+- **REG‑7** `_regression.py` — document that `log_cosh` requires dimensionless inputs.
+- **REG‑9** `_regression.py:175‑176` — clarify that `axis` only applies when
+  `reduction` is `'mean'`/`'sum'`.
+- **FIR‑7** `_firings.py:700` — widen `dt` type hint/doc to `float or brainunit.Quantity`
+  and state the Hz/seconds contract.
+- **FIR‑8** `_firings.py:155‑162` — note that plain‑float `width`/`dt` are assumed seconds.
+- **FY‑1..3** `_fenchel_young.py:61,147,171` — qualify the non‑negativity claim
+  (holds when `max_fun` is a true conjugate and `y` is in its domain), and fix the
+  misleading "L2‑regularized" / complex‑inner‑product comments.
+- **COR‑3** `_correlation.py:452,553` — wrap the `weighted_correlation` and
+  `functional_connectivity_dynamics` examples in `.. code-block:: python` and add
+  expected outputs.
+- **RNK‑2** `_ranking.py:281,291,297,304` — `ranking_softmax_loss` examples print with
+  `print(f"...: {loss:.4f}")` but show no expected output (a strict doctest would fail);
+  added the computed output lines (`Loss: 2.2228`, `Batch loss: 0.4968`,
+  `Weighted loss: 0.4076`, `Individual losses: [0.31326163 0.68026966]`). The
+  module‑level docstring example used `jnp` without importing it — added
+  `import jax.numpy as jnp`.
+- **LFP‑4** `_lfp.py:259` — note that `jnp.hanning` is a *symmetric* window, unlike
+  `scipy.signal.welch`'s periodic default.
+- **SM‑2** `_smoothing.py:31` — return annotation `jnp.ndarray` → `jax.Array`.
+- **UTIL‑1** `_util.py` — document that `axis` is ignored when `reduction='none'`.
+- **CLS‑4** `_classification.py` — note that fractional `gamma` (`0<gamma<1`) with
+  saturated logits yields non‑finite gradients (matches optax/fvcore; default
+  `gamma=2` is safe).
+
+## Documented‑only (no behaviour change — recorded for completeness)
+
+- **CLS‑3** `assert_is_float`/`assert_is_int` surface a `ValueError` (from
+  `u.math.is_float`) rather than their own `TypeError` for raw list inputs.
+- **CLS‑5** `softmax_cross_entropy` yields `NaN` for `-inf` logits at a zero‑label
+  position (`0 * -inf`); matches optax. Use the integer‑label variant / finite logits.
+- **REG‑8** `cosine_similarity` gradient is finite but can be large (~1e7) for
+  near‑zero inputs; the docstring wording is softened.
+- **RNK‑1** `_ranking._safe_reduce` computes its NaN guard over the whole array; this
+  is harmless for the only (whole‑array mean) call site.
+- **LFP‑6** `unitary_LFP` `sig_e` default doc is consistent (`3.15 = 2.1 * 1.5`).
+
+---
+
+## Verification plan
+
+Each behaviour fix gets a focused test (reproducing the bug first, per the
+project's TDD agreement) in `braintools/metric/_audit_20260619_test.py`; the
+docstring‑output fixes are verified by executing the exact example via `doctest`.
+
+**Result:** the full `braintools/metric` suite is green — **357 passed**
+(332 baseline + 25 new audit/regression tests). One pre‑existing test
+(`TestLFPPhaseCoherence.test_different_frequency_bands`) asserted the LFP‑1 bug
+and was updated to the corrected semantics (see LFP‑1). Doctest spot‑checks pass:
+regression 46/0, pairwise 7/0, ranking 18/0, classification (edited fns) 36/0.
+
+## Test infrastructure (per user request)
+
+A repo‑root `conftest.py` forces matplotlib's non‑interactive **Agg** backend for
+the entire test suite (`MPLBACKEND=Agg` set before import + `matplotlib.use("Agg",
+force=True)`), so running the tests never opens GUI image windows and works
+headless/CI. The `braintools/metric` tests themselves use no matplotlib; this
+covers sibling suites (e.g. `braintools/visualize`) when the whole project is run.


### PR DESCRIPTION
## Summary

Senior-developer / JAX-expert audit of every source file in `braintools/metric/` and its docstrings. Each actionable finding was reproduced before being fixed; full report in `docs/braintools-metric-issues-found-20260619.md`.

### High severity
- **`phase_locking_value`** now accepts a `brainunit.Quantity` `dt` (incl. the common `environ.get_dt()` default), converting it to seconds — previously crashed.
- **`L1Loss`** is now exported (`__all__` / `__init__`); `from braintools.metric import L1Loss` previously raised `ImportError` despite the class being public & documented.
- **`pairwise_cosine_similarity`** floors each *row* norm at `eps` instead of the norm *product*, so small non-zero vectors are no longer corrupted (returned 0.09 instead of 1.0).
- **`voltage_fluctuation`** Returns docstring corrected (index is in ~`[1/N, 1]`; near 1 = synchrony, near 1/N = asynchrony — the doc had it inverted).

### Medium severity
- **`cross_correlation`** strips units (`u.get_magnitude`) so `Quantity` input works.
- **`lfp_phase_coherence`** suppresses spurious coherence for channels with negligible in-band power (phase of a ~0 band-limited signal is undefined).
- **`smooth_labels`** validates dtype with `TypeError` instead of a bare `assert` (stripped under `python -O`).
- **`victor_purpura_distance`** builds its DP table on host NumPy arrays instead of per-cell device round-trips — functionally identical, far faster.

### Low severity (behaviour)
`l1_loss` scalar input; `coherence_analysis` empty-band fallback + scale-invariant denominator; `_analytic_band` DC bin not doubled; `sigmoid_binary_cross_entropy` list inputs; `burst_synchrony_index` endpoint-touching bursts; `correlation_index` `[-1,1]` clamp + dead-code removal; `cross_correlation` typed `lax.cond` branch; `_safe_row_norm` `axis=-1`.

### Documentation
Refreshed stale docstring example outputs (numpy shortest-repr) and added missing expected outputs / code-blocks across regression, pairwise, classification, ranking; clarified `log_cosh` broadcasting/dimensionless, `squared_error` axis, focal-loss fractional-gamma gradient, Fenchel-Young notes, PSD Hann-window note, `_reduce` axis note, smoothing return annotation.

## Tests / infra
- New `braintools/metric/_audit_20260619_test.py` — **25 regression tests** (one per behaviour fix, bug reproduced first per the project's TDD agreement).
- Updated `TestLFPPhaseCoherence.test_different_frequency_bands`, which had asserted the spurious-coherence bug, to the corrected semantics.
- New repo-root `conftest.py` forcing matplotlib's **Agg** backend for the whole suite (no GUI windows / headless-safe).

**Full `braintools/metric` suite green: 357 passed** (332 baseline + 25 new). Doctest spot-checks pass (regression 46/0, pairwise 7/0, ranking 18/0, classification edited fns 36/0).