### PR TITLE
fix(cogtask): Parallel compound children, make_encoder scalar, create_task export & broken docstrings

### DIFF
--- a/braintools/cogtask/__init__.py
+++ b/braintools/cogtask/__init__.py
@@ -35,7 +35,7 @@ Building custom tasks from phases:
 >>> from braintools.cogtask import (
 ...     Task, Context, concat,
 ...     Fixation, Stimulus, Delay, Response,
-...     Feature, circular, one_hot
+...     Feature, circular, one_hot, label
 ... )
 >>> import brainunit as u
 >>>
@@ -44,13 +44,14 @@ Building custom tasks from phases:
 >>> stim = Feature(8, 'stimulus')
 >>> choice = Feature(2, 'choice')
 >>>
->>> # Build task
+>>> # Build task. A string label spec must be wrapped in ``label(...)`` so it
+>>> # is read as a context key; a bare string is treated as a literal and fails.
 >>> task = Task(
 ...     phases=concat([
 ...         Fixation(100 * u.ms, inputs={'fixation': 1.0}),
 ...         Stimulus(500 * u.ms, inputs={'stimulus': circular('direction')}),
 ...         Delay(500 * u.ms, inputs={'fixation': 1.0}),
-...         Response(100 * u.ms, outputs={'label': 'ground_truth'})
+...         Response(100 * u.ms, outputs={'label': label('ground_truth')})
 ...     ]),
 ...     input_features=fix + stim,
 ...     output_features=fix + choice,
@@ -153,7 +154,7 @@ from .phase import (
     execute_phase_packed,
     phase_tree_is_variable,
 )
-from .task import Task
+from .task import Task, create_task
 # Pre-built tasks
 from .tasks import (
     # Decision Making
@@ -215,6 +216,7 @@ __all__ = [
     'Switch',
     'While',
     'Task',
+    'create_task',
     # Features
     'Feature',
     'FeatureSet',

--- a/braintools/cogtask/context.py
+++ b/braintools/cogtask/context.py
@@ -36,19 +36,25 @@ class Context:
 
     Examples
     --------
-    >>> ctx = Context(seed=42)
-    >>> ctx['ground_truth'] = 1
-    >>> ctx['stimulus_direction'] = 0.5 * np.pi
-    >>> print(ctx['ground_truth'])
-    1
+    .. code-block:: python
 
-    >>> # In a phase:
-    >>> ctx.inputs[ctx.phase_start:ctx.phase_end, :] = stimulus_encoding
+        >>> import jax
+        >>> import jax.numpy as jnp
+        >>> ctx = Context(key=jax.random.PRNGKey(42))
+        >>> ctx['ground_truth'] = 1
+        >>> ctx['stimulus_direction'] = 0.5 * jnp.pi
+        >>> print(ctx['ground_truth'])
+        1
+
+        >>> # In a phase, write into the buffer with a functional update
+        >>> # (JAX arrays are immutable; ``.at[...].set(...)`` returns a copy):
+        >>> # ctx.inputs = ctx.inputs.at[ctx.phase_start:ctx.phase_end, :].set(stimulus_encoding)
 
     Parameters
     ----------
     key : jax.Array, optional
-        JAX PRNGKey for random number generation. If None, creates one with seed.
+        JAX PRNGKey for random number generation. If None, draws fresh
+        randomness from brainstate's default RNG.
 
     Note
     ----

--- a/braintools/cogtask/feature.py
+++ b/braintools/cogtask/feature.py
@@ -300,7 +300,7 @@ class Feature(_FeatureBase):
         """
         Create multiple copies of this feature with indexed names.
 
-        Example: Feature(1, 30.*u.Hz, 'choice') * 3
+        Example: Feature(1, 'choice') * 3
         Creates: choice_0, choice_1, choice_2
         """
         if not isinstance(count, int) or count < 1:

--- a/braintools/cogtask/phase.py
+++ b/braintools/cogtask/phase.py
@@ -457,25 +457,33 @@ class Parallel(Phase):
         pass
 
     def execute(self, ctx: Context) -> None:
-        """Encode each child within its own [phase_start, phase_start+dur)."""
+        """Encode each child within its own ``[parent_start, parent_start+dur)``.
+
+        Every child — leaf *or* compound — is dispatched through
+        ``execute_phase`` so that nested ``Sequence``/``Repeat``/conditional
+        children execute correctly. Routing compound children through
+        ``encode_inputs``/``encode_outputs`` directly would be a no-op (those
+        classes drive their sub-phases via ``execute``), silently dropping the
+        branch. This mirrors ``execute_packed`` and keeps the two paths
+        consistent. All children start at ``parent_start``; only the first child
+        contributes to the output buffer by convention.
+        """
         parent_start = ctx.phase_start
         parent_end = ctx.phase_end
         parent_name = ctx.current_phase
 
         for i, child in enumerate(self.phases):
-            child_dur = child.get_duration(ctx)
-            ctx.phase_start = parent_start
-            ctx.phase_end = parent_start + child_dur
-            ctx.current_phase = child.name
-            child.on_enter(ctx)
-            child.encode_inputs(ctx)
-            # Only the first child contributes outputs by default.
+            ctx.current_step = parent_start
             if i == 0:
-                child.encode_outputs(ctx)
-            child.on_exit(ctx)
-            ctx.phase_history.append((child.name, ctx.phase_start, ctx.phase_end))
+                execute_phase(child, ctx)
+            else:
+                # Non-first children must not contribute to the output buffer.
+                # Stash, encode (inputs + any state), then restore outputs.
+                saved_out = ctx.outputs
+                execute_phase(child, ctx)
+                ctx.outputs = saved_out
 
-        # Restore parent scope.
+        # Restore parent scope and advance past the (longest) child.
         ctx.phase_start = parent_start
         ctx.phase_end = parent_end
         ctx.current_phase = parent_name

--- a/braintools/cogtask/phase_test.py
+++ b/braintools/cogtask/phase_test.py
@@ -333,3 +333,63 @@ def test_describe_lists_inputs_outputs_and_noise():
     s = p.describe()
     assert "Inputs" in s and "Outputs" in s and "Noise" in s
     assert "fixation" in s
+
+
+def test_parallel_executes_compound_child_eager():
+    # Regression: a compound child (Sequence) of a Parallel must execute its
+    # sub-phases. Previously Parallel.execute called encode_inputs directly,
+    # which is a no-op for compounds, so the whole branch was silently dropped.
+    m = ct.Feature(1, 'm')
+    n = ct.Feature(1, 'n')
+    fix = ct.Feature(1, 'fixation')
+    a = Stimulus(5 * u.ms, name='A', inputs={'m': 1.0}, outputs={'label': 0})
+    b = Stimulus(5 * u.ms, name='B', inputs={'m': 1.0}, outputs={'label': 0})
+    seq_ab = a >> b                      # compound child
+    c = Stimulus(10 * u.ms, name='C', inputs={'n': 1.0}, outputs={'label': 0})
+    par = seq_ab | c
+    task = ct.Task(
+        phases=par,
+        input_features=m + n + fix,
+        output_features=fix + ct.Feature(1, 'out'),
+        seed=0,
+    )
+    X, _, _ = task.sample_trial(0)
+    X = np.asarray(X)
+    assert X.shape[0] == 10
+    # A and B each ran for 5 ticks writing 1.0 into channel 'm' -> sum == 10.
+    np.testing.assert_allclose(X[:, 0].sum(), 10.0, atol=1e-6)
+    # C ran for all 10 ticks writing 1.0 into channel 'n'.
+    np.testing.assert_allclose(X[:, 1], 1.0, atol=1e-6)
+
+
+def test_parallel_eager_and_packed_agree_on_compound_child():
+    # The fixed (eager) and variable (packed) execution paths must produce the
+    # same input channels for a Parallel whose first child is a compound, when
+    # all durations are fully realised.
+    m = ct.Feature(1, 'm')
+    n = ct.Feature(1, 'n')
+    fix = ct.Feature(1, 'fixation')
+
+    def build(extra_phase):
+        a = Stimulus(5 * u.ms, name='A', inputs={'m': 1.0}, outputs={'label': 0})
+        b = Stimulus(5 * u.ms, name='B', inputs={'m': 1.0}, outputs={'label': 0})
+        c = Stimulus(10 * u.ms, name='C', inputs={'n': 1.0}, outputs={'label': 0})
+        phases = (a >> b) | c
+        if extra_phase is not None:
+            phases = phases >> extra_phase
+        return ct.Task(phases=phases, input_features=m + n + fix,
+                       output_features=fix + ct.Feature(1, 'out'), seed=0)
+
+    # Eager path.
+    X_eager, _, _ = build(None).sample_trial(0)
+    # Packed path: append a VariableDuration whose realised length is fixed via
+    # trial_init, forcing packed mode but the same total realised content.
+    vd = ct.VariableDuration(min_duration=2 * u.ms, max_duration=4 * u.ms,
+                             ctx_key='d', inputs={'n': 1.0}, outputs={'label': 0},
+                             name='vd')
+    packed_task = build(vd)
+    packed_task._trial_init_func = lambda ctx: ctx.update(d=4.0)
+    X_packed, _, info = packed_task.sample_trial(0)
+    # The Parallel block occupies the first 10 ticks in both; compare them.
+    np.testing.assert_allclose(np.asarray(X_eager)[:10, 0],
+                               np.asarray(X_packed)[:10, 0], atol=1e-6)

--- a/braintools/cogtask/task.py
+++ b/braintools/cogtask/task.py
@@ -86,17 +86,22 @@ class Task:
     --------
     Instance-based (traditional):
 
+    >>> import brainunit as u
+    >>> from braintools.cogtask import Feature, Fixation, Stimulus, Response, circular, label
+    >>> fix = Feature(1, 'fixation')
+    >>> stim = Feature(8, 'stimulus')
+    >>> choice = Feature(2, 'choice')
     >>> task = Task(
     ...     phases=(
-    ...         Fixation(100 * u.ms)
-    ...         >> Stimulus(2000 * u.ms, feature=stim, encoder=circular_encoder())
-    ...         >> Response(100 * u.ms, output_feature=choice)
+    ...         Fixation(100 * u.ms, inputs={'fixation': 1.0})
+    ...         >> Stimulus(2000 * u.ms, inputs={'stimulus': circular('direction')})
+    ...         >> Response(100 * u.ms, outputs={'label': label('ground_truth')})
     ...     ),
     ...     input_features=fix + stim,
     ...     output_features=fix + choice,
     ...     trial_init=lambda ctx: ctx.update(
     ...         ground_truth=ctx.rng.choice(2),
-    ...         direction=ctx.rng.uniform(0, 2*np.pi)
+    ...         direction=ctx.rng.uniform(0, 2 * 3.14159)
     ...     )
     ... )
 
@@ -107,12 +112,13 @@ class Task:
     ...     num_stimuli = 8
     ...
     ...     def define_features(self):
-    ...         fix = Feature(1, 40*u.Hz, 'fixation')
-    ...         stim = Feature(self.num_stimuli, 40*u.Hz, 'stimulus')
-    ...         return fix + stim, fix + Feature(2, 40*u.Hz, 'response')
+    ...         fix = Feature(1, 'fixation')
+    ...         stim = Feature(self.num_stimuli, 'stimulus')
+    ...         return fix + stim, fix + Feature(2, 'response')
     ...
     ...     def define_phases(self):
-    ...         return FixationPhase(self.t_fixation) >> ResponsePhase()
+    ...         return (Fixation(self.t_fixation, inputs={'fixation': 1.0})
+    ...                 >> Response(100 * u.ms, outputs={'label': label('ground_truth')}))
     ...
     ...     def trial_init(self, ctx):
     ...         ctx['ground_truth'] = ctx.rng.choice(2)
@@ -631,11 +637,20 @@ def create_task(
 
     Examples
     --------
+    >>> import brainunit as u
+    >>> from braintools.cogtask import Feature, Fixation, Stimulus, Response, circular, label
     >>> task = create_task(
-    ...     phases=Fixation(100*u.ms) >> Stimulus(500*u.ms) >> Response(100*u.ms),
-    ...     input_features=Feature('fix', 1) + Feature('stim', 2),
-    ...     output_features=Feature('fix', 1) + Feature('choice', 2),
-    ...     num_trial=1000
+    ...     phases=(
+    ...         Fixation(100 * u.ms, inputs={'fixation': 1.0})
+    ...         >> Stimulus(500 * u.ms, inputs={'stimulus': circular('direction')})
+    ...         >> Response(100 * u.ms, outputs={'label': label('ground_truth')})
+    ...     ),
+    ...     input_features=Feature(1, 'fixation') + Feature(2, 'stimulus'),
+    ...     output_features=Feature(1, 'fixation') + Feature(2, 'choice'),
+    ...     trial_init=lambda ctx: ctx.update(
+    ...         ground_truth=ctx.rng.choice(2),
+    ...         direction=ctx.rng.uniform(0, 2 * 3.14159)
+    ...     ),
     ... )
     """
     return Task(phases, input_features, output_features, trial_init, name,

--- a/braintools/cogtask/task_test.py
+++ b/braintools/cogtask/task_test.py
@@ -387,3 +387,36 @@ def test_pulse_decision_making_runs_through_repeat():
         gt = int(info['trial_state']['ground_truth'])
         last = int(np.asarray(Y)[-1])
         assert last == gt + 1
+
+
+# ---------------------------------------------------------------------------
+# create_task factory: must be exported from the package and produce a
+# sampleable task. Also exercises the (previously broken) docstring pattern
+# of a string label spec wrapped in label(...).
+# ---------------------------------------------------------------------------
+
+def test_create_task_is_exported_from_package():
+    assert hasattr(ct, 'create_task')
+    assert 'create_task' in ct.__all__
+
+
+def test_create_task_builds_sampleable_task_with_string_label():
+    task = ct.create_task(
+        phases=(
+            ct.Fixation(10 * u.ms, inputs={'fixation': 1.0})
+            >> ct.Stimulus(20 * u.ms, inputs={'stimulus': ct.circular('direction')})
+            >> ct.Response(10 * u.ms, outputs={'label': ct.label('ground_truth')})
+        ),
+        input_features=ct.Feature(1, 'fixation') + ct.Feature(2, 'stimulus'),
+        output_features=ct.Feature(1, 'fixation') + ct.Feature(2, 'choice'),
+        trial_init=lambda ctx: ctx.update(
+            ground_truth=ctx.rng.choice(2),
+            direction=ctx.rng.uniform(0, 2 * 3.14159),
+        ),
+        seed=0,
+    )
+    X, Y, info = task.sample_trial(0)
+    assert X.shape[0] == Y.shape[0] == 40
+    gt = int(info['trial_state']['ground_truth'])
+    # Response phase is the last 10 ticks; label == ground_truth there.
+    assert (np.asarray(Y)[-10:] == gt).all()

--- a/braintools/cogtask/tasks/working_memory.py
+++ b/braintools/cogtask/tasks/working_memory.py
@@ -62,6 +62,13 @@ def make_encoder(mode: str, key: str, *, feature_per_direction: int = 1, kappa=2
     """
     mode = mode.lower()
 
+    # ``scalar`` broadcasts a single value across every feature dimension, so it
+    # is agnostic to ``feature_per_direction`` — handle it up front rather than
+    # only in the K == 1 branch (otherwise scalar + K>1 fell through to the
+    # population branch and raised a misleading "Unknown mode=scalar").
+    if mode == "scalar":
+        return scalar(key)
+
     if feature_per_direction == 1:
         if mode == "von_mises":
             return von_mises(key, kappa=kappa, base_value=base_value, as_index=True, num_dirs=num_dirs)
@@ -69,8 +76,6 @@ def make_encoder(mode: str, key: str, *, feature_per_direction: int = 1, kappa=2
             return one_hot(key)
         elif mode == "circular":
             return circular(key, base_value=base_value, as_index=True, num_dirs=num_dirs)
-        elif mode == "scalar":
-            return scalar(key)
         else:
             raise ValueError(f"Unknown mode={mode}")
 

--- a/braintools/cogtask/tasks/working_memory_test.py
+++ b/braintools/cogtask/tasks/working_memory_test.py
@@ -67,6 +67,20 @@ def test_make_encoder_population_dim_not_divisible_raises():
         enc(ctx, f)
 
 
+@pytest.mark.parametrize("k", [1, 3, 5])
+def test_make_encoder_scalar_is_feature_per_direction_agnostic(k):
+    # Regression: scalar was only handled in the K==1 branch, so
+    # feature_per_direction>1 raised "Unknown mode=scalar". scalar broadcasts a
+    # single value across all dims and must work for any K.
+    enc = make_encoder("scalar", "sample_value", feature_per_direction=k)
+    f = ct.Feature(6, 'stimulus')
+    ctx = ct.Context()
+    ctx['sample_value'] = 0.7
+    out = np.asarray(enc(ctx, f))
+    assert out.shape == (6,)
+    np.testing.assert_allclose(out, 0.7, atol=1e-6)
+
+
 def test_build_cues_returns_jax_arrays_with_right_shapes():
     non_resp, resp = build_cues(3)
     assert non_resp.shape == (3,)

--- a/docs/braintools-cogtask-issues-found-20260619.md
+++ b/docs/braintools-cogtask-issues-found-20260619.md
@@ -1,0 +1,211 @@
+# braintools/cogtask — Issues Found (2026-06-19)
+
+Audit of the `braintools/cogtask/` module and its in-code documentation, from
+the perspective of a senior Python developer / JAX expert. Each issue below was
+reproduced before being listed. Baseline before fixes: `276 passed`.
+
+Severity legend: **[High]** silent wrong results / crashes on supported usage ·
+**[Med]** misleading errors or unreachable public API · **[Low]** documentation
+examples that do not run.
+
+---
+
+## Issue 1 — [High] `Parallel.execute` silently drops compound children
+
+**File:** `braintools/cogtask/phase.py`, `Parallel.execute`.
+
+The eager (fixed-length) execution path calls `child.encode_inputs(ctx)` /
+`child.encode_outputs(ctx)` **directly** on each parallel child:
+
+```python
+for i, child in enumerate(self.phases):
+    ...
+    child.encode_inputs(ctx)
+    if i == 0:
+        child.encode_outputs(ctx)
+```
+
+For *compound* children (`Sequence`, `Repeat`, `If`, `Switch`, `While`, nested
+`Parallel`) `encode_inputs`/`encode_outputs` are no-ops — those classes drive
+their sub-phases through `execute()`, not through the encode hooks. As a result
+a construct like `(A >> B) | C` writes **nothing** for the `A >> B` branch: the
+sub-sequence is silently skipped and its input channels stay at zero.
+
+The packed/variable-length path (`Parallel.execute_packed`) does *not* have this
+bug — it dispatches every child through `execute_phase_packed`, which handles
+both leaves and compounds. So the two execution paths disagree.
+
+**Reproduction**
+
+```python
+seqAB = a >> b                  # a, b write input channel 'm'
+par   = seqAB | c               # c writes channel 'n'
+X, Y, info = task.sample_trial(0)
+# eager:  sum(X[:, m]) == 0.0   ← seqAB silently dropped (BUG)
+# packed: sum(X[:, m]) == 40.0  ← seqAB executed correctly
+```
+
+**Proposed solution.** Dispatch each parallel child through `execute_phase`
+(mirroring `execute_packed`), restoring the parent scope afterward. All children
+start at `parent_start`; only the first contributes to the output buffer (stash
+& restore `ctx.outputs` for `i > 0`). This fixes compound children, preserves
+the existing leaf behaviour (the built-in `modality1 | modality2` /
+`Fixation | Cue` tasks are unchanged), and makes both paths consistent.
+
+---
+
+## Issue 2 — [Med] `make_encoder(mode="scalar", feature_per_direction>1)` raises a misleading error
+
+**File:** `braintools/cogtask/tasks/working_memory.py`, `make_encoder`.
+
+`"scalar"` is only handled in the `feature_per_direction == 1` branch. When
+`feature_per_direction > 1` the function falls through to the population branch,
+which only knows `one_hot`/`von_mises`/`circular`, and raises
+`ValueError("Unknown mode=scalar")`. But `scalar` broadcasts its value across
+*all* `feature.num` dims and is completely agnostic to `feature_per_direction`,
+so the call should simply work.
+
+**Reproduction**
+
+```python
+make_encoder("scalar", "sample_idx", feature_per_direction=4)
+# ValueError: Unknown mode=scalar   ← misleading; scalar is K-agnostic
+```
+
+**Proposed solution.** Handle `"scalar"` up front (before the `K == 1`
+special-casing) and return `scalar(key)` regardless of `feature_per_direction`.
+
+---
+
+## Issue 3 — [Low] Package-level quickstart docstring uses a raw string label that cannot be encoded
+
+**File:** `braintools/cogtask/__init__.py` (module docstring).
+
+The "Building custom tasks from phases" example ends with:
+
+```python
+Response(100 * u.ms, outputs={'label': 'ground_truth'})
+```
+
+`DeclarativePhase.encode_outputs` does **not** treat a bare string as a context
+key — it passes it to `jnp.asarray(..., dtype=jnp.int32)`, which raises
+`ValueError: invalid literal for int() with base 10: 'ground_truth'`. The
+`label()` helper is what interprets a string as a context key.
+
+**Reproduction:** running the docstring example verbatim raises the `ValueError`
+above.
+
+**Proposed solution.** Use the `label` helper: `outputs={'label':
+label('ground_truth')}`, and add `label` to the example's imports.
+
+---
+
+## Issue 4 — [Low] `Task` class docstring examples use APIs that do not exist
+
+**File:** `braintools/cogtask/task.py` (`Task` docstring).
+
+Two examples are broken against the current API:
+
+* Instance-based: `Stimulus(2000 * u.ms, feature=stim, encoder=circular_encoder())`
+  — `DeclarativePhase`/`Stimulus` take `inputs=`/`outputs=`, not `feature=`/
+  `encoder=`; `circular_encoder` does not exist.
+* Class-based: `Feature(1, 40*u.Hz, 'fixation')` — `Feature.__init__(num,
+  name=None)` takes no firing-rate argument; this raises
+  `TypeError: ... takes from 2 to 3 positional arguments but 4 were given`.
+
+**Proposed solution.** Rewrite both examples against the real API
+(`Feature(num, name)`, `Stimulus(duration, inputs=..., outputs=...)`).
+
+---
+
+## Issue 5 — [Low] `create_task` docstring example is broken (wrong arg order + invalid kwarg)
+
+**File:** `braintools/cogtask/task.py` (`create_task` docstring).
+
+```python
+input_features=Feature('fix', 1) + Feature('stim', 2),   # name/num swapped
+...
+num_trial=1000                                            # not a Task kwarg
+```
+
+`Feature('fix', 1)` silently produces a nonsensical feature with `num='fix'`
+(a string) and `name=1`; `num_trial=1000` is forwarded via `**kwargs` and set as
+a stray attribute. The example never runs as intended.
+
+**Proposed solution.** Fix to `Feature(1, 'fix')` etc. and drop the invalid
+`num_trial` kwarg.
+
+---
+
+## Issue 6 — [Low] `Feature.__mul__` docstring uses the obsolete 3-argument signature
+
+**File:** `braintools/cogtask/feature.py` (`Feature.__mul__` docstring).
+
+`Example: Feature(1, 30.*u.Hz, 'choice') * 3` — same obsolete firing-rate
+signature as Issue 4. Should be `Feature(1, 'choice') * 3`.
+
+---
+
+## Issue 7 — [Low] `Context` docstring constructor & buffer examples do not run
+
+**File:** `braintools/cogtask/context.py` (`Context` docstring).
+
+* `Context(seed=42)` — `Context.__init__` accepts `key=`, not `seed=`.
+* `ctx.inputs[ctx.phase_start:ctx.phase_end, :] = stimulus_encoding` — `inputs`
+  is a JAX array; item assignment is not supported (`.at[...].set(...)` is).
+* Uses `np.pi` without importing `numpy`.
+
+**Proposed solution.** Use `key=` (or no argument), reference the functional
+`.at[...].set(...)` update, and use `jax.numpy` consistently.
+
+---
+
+## Issue 8 — [Med] `create_task` is declared public but not exported from the package
+
+**Files:** `braintools/cogtask/task.py` (`__all__` lists `create_task`) vs.
+`braintools/cogtask/__init__.py` (neither imports nor re-exports it).
+
+`create_task` has a full public docstring and is in `task.py`'s `__all__`, yet
+`braintools.cogtask.create_task` raises `AttributeError`. Either it is public
+(then export it) or private (then drop it from `__all__`). Since it is a
+documented convenience factory, the right fix is to export it.
+
+**Proposed solution.** Import `create_task` in `__init__.py` and add it to the
+package `__all__`.
+
+---
+
+## Observations (documented behaviour / lower risk — not changed)
+
+These are noted for completeness; they are either already documented or carry
+behaviour-change risk that outweighs the benefit of a code change:
+
+* **`Task.num_classes` over-reports for DMS-style tasks when `cue_dim > 1`.**
+  The categorical label space of DMS tasks is fixed (e.g. `{0, 1, 2}`), but the
+  default `num_classes` falls back to `num_outputs = cue_dim + 2`. This is
+  explicitly documented on the `Task.num_classes` property ("drifts apart when
+  e.g. `cue_dim` changes; pass `num_classes=` explicitly"). Left as documented
+  guidance.
+* **`ContextDecisionMaking` with `num_contexts > 2`.** Only two stimulus
+  modalities exist; the ground-truth selection treats context `0` as "attend
+  modality 1" and every other context as "attend modality 2". A reasonable
+  interpretation, but worth knowing.
+* **`utils.choice(rng, n_total=1, ...)`** samples from an empty set; only
+  relevant for the degenerate `num_stimuli == 1` configuration of match tasks.
+
+---
+
+## Test plan
+
+Regression tests are added under the existing `cogtask` test suite:
+
+1. **Parallel compound child (eager)** — `(A >> B) | C` writes the `A`/`B`
+   channels; assert the eager and packed paths agree.
+2. **`make_encoder` scalar + `feature_per_direction>1`** — returns a working
+   encoder and broadcasts the scalar across all dims.
+3. **`create_task` export** — importable from `braintools.cogtask` and produces
+   a sampleable task.
+4. **Fixed docstring behaviours** — `outputs={'label': label('ground_truth')}`
+   samples without error.
+
+All pre-existing tests must continue to pass.


### PR DESCRIPTION
## Summary

Senior-dev / JAX audit of `braintools/cogtask/` and its in-code documentation. Each issue was reproduced before fixing; full details and proposed solutions are in `docs/braintools-cogtask-issues-found-20260619.md`.

## Code fixes

- **`Parallel.execute` silently dropped compound children** (High). A `Sequence`/`Repeat`/conditional child of a `|` was skipped entirely because `encode_inputs`/`encode_outputs` are no-ops for compound phases — e.g. `(A >> B) | C` wrote nothing for the `A >> B` branch in eager mode (the packed path was already correct). Children are now dispatched through `execute_phase`, making the two paths consistent.
- **`make_encoder(mode="scalar", feature_per_direction>1)`** raised a misleading `Unknown mode=scalar` (Med). `scalar` is K-agnostic and is now handled up front.
- **`create_task` not exported** (Med). It was in `task.__all__` but neither imported nor re-exported by the package; now importable as `braintools.cogtask.create_task`.

## Documentation fixes (examples that did not run)

- `__init__` quickstart used a bare string label spec (`'ground_truth'`) — must be `label('ground_truth')`.
- `Task` docstring used the removed `Feature(num, Hz, name)` signature and nonexistent `Stimulus(feature=, encoder=)` kwargs.
- `create_task` docstring swapped `Feature(name, num)` order and passed an invalid `num_trial` kwarg.
- `Feature.__mul__` docstring used the obsolete 3-arg signature.
- `Context` docstring used `Context(seed=)` (no such param), mutable buffer assignment, and undefined `np`.

## Tests

Added regression tests: eager/packed `Parallel` agreement on compound children, `make_encoder` scalar across `feature_per_direction`, and `create_task` export + string-label sampling.

`python -m pytest braintools/cogtask` → **283 passed** (276 baseline + 7 new). All fixed docstring examples verified to run.